### PR TITLE
add GetHistoryByLabelID interface with unit test, Register history's UrlPatterns to chassis

### DIFF
--- a/cmd/kieserver/main.go
+++ b/cmd/kieserver/main.go
@@ -18,12 +18,13 @@
 package main
 
 import (
-	"github.com/apache/servicecomb-kie/server/db"
 	"os"
+
+	"github.com/apache/servicecomb-kie/server/db"
 
 	"github.com/apache/servicecomb-kie/server/config"
 	_ "github.com/apache/servicecomb-kie/server/handler"
-	"github.com/apache/servicecomb-kie/server/resource/v1"
+	v1 "github.com/apache/servicecomb-kie/server/resource/v1"
 	"github.com/go-chassis/go-chassis"
 	"github.com/go-mesh/openlogging"
 	"github.com/urfave/cli"
@@ -72,6 +73,7 @@ func main() {
 		openlogging.Fatal(err.Error())
 	}
 	chassis.RegisterSchema("rest", &v1.KVResource{})
+	chassis.RegisterSchema("rest", &v1.HistoryResource{})
 	if err := chassis.Init(); err != nil {
 		openlogging.Fatal(err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,21 +3,19 @@ module github.com/apache/servicecomb-kie
 require (
 	github.com/emicklei/go-restful v2.8.0+incompatible
 	github.com/go-chassis/foundation v0.0.0-20190621030543-c3b63f787f4c
-	github.com/go-chassis/go-archaius v0.19.0
-	github.com/go-chassis/go-chassis v1.6.1-0.20190719075922-5d5163a39259
+	github.com/go-chassis/go-archaius v0.20.0
+	github.com/go-chassis/go-chassis v1.6.2-0.20190730080139-fcfd929304bc
 	github.com/go-chassis/paas-lager v1.0.2-0.20190328010332-cf506050ddb2
 	github.com/go-mesh/openlogging v1.0.1-0.20181205082104-3d418c478b2d
+	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	github.com/tidwall/pretty v1.0.0 // indirect
-	github.com/uber-go/atomic v1.4.0 // indirect
 	github.com/urfave/cli v1.20.0
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.0.0
-	go.uber.org/atomic v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,20 @@ require (
 	github.com/emicklei/go-restful v2.8.0+incompatible
 	github.com/go-chassis/foundation v0.0.0-20190621030543-c3b63f787f4c
 	github.com/go-chassis/go-archaius v0.19.0
-	github.com/go-chassis/go-chassis v1.5.1
+	github.com/go-chassis/go-chassis v1.6.1-0.20190719075922-5d5163a39259
 	github.com/go-chassis/paas-lager v1.0.2-0.20190328010332-cf506050ddb2
 	github.com/go-mesh/openlogging v1.0.1-0.20181205082104-3d418c478b2d
+	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
+	github.com/tidwall/pretty v1.0.0 // indirect
+	github.com/uber-go/atomic v1.4.0 // indirect
 	github.com/urfave/cli v1.20.0
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
-	go.mongodb.org/mongo-driver v1.0.3
+	go.mongodb.org/mongo-driver v1.0.0
+	go.uber.org/atomic v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.1
 )

--- a/pkg/model/kv.go
+++ b/pkg/model/kv.go
@@ -28,3 +28,11 @@ type LabelDocResponse struct {
 	LabelID string            `json:"label_id,omitempty"`
 	Labels  map[string]string `json:"labels,omitempty"`
 }
+
+//LabelHistoryResponse is label history revision struct
+type LabelHistoryResponse struct {
+	LabelID  string            `json:"label_id,omitempty"  bson:"label_id,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+	KVs      []*KVDoc          `json:"data,omitempty"`
+	Revision int               `json:"revision"`
+}

--- a/pkg/model/mongodb_doc.go
+++ b/pkg/model/mongodb_doc.go
@@ -46,7 +46,7 @@ type LabelRevisionDoc struct {
 	ID       primitive.ObjectID `json:"_id,omitempty" bson:"_id,omitempty"`
 	LabelID  string             `json:"label_id,omitempty"  bson:"label_id,omitempty"`
 	Labels   map[string]string  `json:"labels,omitempty"`
-	Domain   string             `json:"domain,omitempty" bson:"-"`
+	Domain   string             `json:"-"`
 	KVs      []*KVDoc           `json:"data,omitempty"`
 	Revision int                `json:"revision"`
 }

--- a/pkg/model/mongodb_doc.go
+++ b/pkg/model/mongodb_doc.go
@@ -45,8 +45,8 @@ type KVDoc struct {
 type LabelRevisionDoc struct {
 	ID       primitive.ObjectID `json:"_id,omitempty" bson:"_id,omitempty"`
 	LabelID  string             `json:"label_id,omitempty"  bson:"label_id,omitempty"`
-	Labels   map[string]string  `json:"labels,omitempty"` //redundant
-	Domain   string             `json:"domain,omitempty"` //redundant
-	KVs      []*KVDoc           `json:"data,omitempty"`   // save states of this revision
+	Labels   map[string]string  `json:"labels,omitempty"`
+	Domain   string             `json:"domain,omitempty" bson:"-"`
+	KVs      []*KVDoc           `json:"data,omitempty"`
 	Revision int                `json:"revision"`
 }

--- a/server/resource/v1/doc_struct.go
+++ b/server/resource/v1/doc_struct.go
@@ -44,6 +44,11 @@ var (
 		Name:      "key",
 		ParamType: goRestful.PathParameterKind,
 	}
+	DocPathLabelID = &restful.Parameters{
+		DataType:  "string",
+		Name:      "label_id",
+		ParamType: goRestful.PathParameterKind,
+	}
 	kvIDParameters = &restful.Parameters{
 		DataType:  "string",
 		Name:      "kvID",

--- a/server/resource/v1/history_resource.go
+++ b/server/resource/v1/history_resource.go
@@ -76,7 +76,7 @@ func (r *HistoryResource) URLPatterns() []restful.Route {
 				{
 					Code:    http.StatusOK,
 					Message: "true",
-					Model:   []*model.LabelHistoryResponse{},
+					Model:   []model.LabelHistoryResponse{},
 				},
 			},
 			Consumes: []string{goRestful.MIME_JSON},

--- a/server/resource/v1/history_resource_test.go
+++ b/server/resource/v1/history_resource_test.go
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package v1_test
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/go-chassis/go-chassis/core/common"
+	"github.com/go-chassis/go-chassis/core/handler"
+	"github.com/go-chassis/go-chassis/core/invocation"
+
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/apache/servicecomb-kie/pkg/model"
+	"github.com/apache/servicecomb-kie/server/db"
+	kvsvc "github.com/apache/servicecomb-kie/server/service/kv"
+
+	"github.com/apache/servicecomb-kie/server/config"
+	v1 "github.com/apache/servicecomb-kie/server/resource/v1"
+	"github.com/go-chassis/go-chassis/server/restful/restfultest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type FakeHandler struct{}
+
+func (fh *FakeHandler) Handle(chain *handler.Chain, i *invocation.Invocation, cb invocation.ResponseCallBack) {
+	i.SetMetadata("domain", "default")
+	r := &invocation.Response{}
+	cb(r)
+}
+
+func (fh *FakeHandler) Name() string {
+	return "fake"
+}
+
+func newFakeHandler() handler.Handler {
+	return &FakeHandler{}
+}
+
+var _ = Describe("v1 history resource", func() {
+
+	config.Configurations = &config.Config{
+		DB: config.DB{},
+	}
+
+	Describe("get history revisions", func() {
+		config.Configurations.DB.URI = "mongodb://kie:123@127.0.0.1:27017"
+		err := db.Init()
+		It("should not return err", func() {
+			Expect(err).Should(BeNil())
+		})
+		Context("valid param", func() {
+			kv := &model.KVDoc{
+				Key:   "test",
+				Value: "revisions",
+				Labels: map[string]string{
+					"test": "revisions",
+				},
+			}
+			kv, _ = kvsvc.CreateOrUpdate(context.Background(), "default", kv)
+			path := fmt.Sprintf("/v1/revision/%s", kv.LabelID)
+			r, _ := http.NewRequest("GET", path, nil)
+			revision := &v1.HistoryResource{}
+			handler.RegisterHandler("fake", newFakeHandler)
+			chain, _ := handler.CreateChain(common.Provider, "testRevisions", "fake")
+			c, err := restfultest.New(revision, chain)
+			It("should not return err or nil", func() {
+				Expect(err).Should(BeNil())
+			})
+			resp := httptest.NewRecorder()
+			c.ServeHTTP(resp, r)
+
+			body, err := ioutil.ReadAll(resp.Body)
+			It("should not return err", func() {
+				Expect(err).Should(BeNil())
+			})
+			data := []*model.LabelRevisionDoc{}
+			err = json.Unmarshal(body, &data)
+			It("should not return err", func() {
+				Expect(err).Should(BeNil())
+			})
+
+			It("should return all revisions with the same label ID", func() {
+				Expect(len(data) > 0).Should(Equal(true))
+				Expect((data[0]).LabelID).Should(Equal(kv.LabelID))
+			})
+		})
+	})
+})

--- a/server/resource/v1/history_resource_test.go
+++ b/server/resource/v1/history_resource_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-chassis/go-chassis/core/common"
 	"github.com/go-chassis/go-chassis/core/handler"
-	"github.com/go-chassis/go-chassis/core/invocation"
 
 	"fmt"
 	"net/http"
@@ -40,22 +39,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
-type FakeHandler struct{}
-
-func (fh *FakeHandler) Handle(chain *handler.Chain, i *invocation.Invocation, cb invocation.ResponseCallBack) {
-	i.SetMetadata("domain", "default")
-	r := &invocation.Response{}
-	cb(r)
-}
-
-func (fh *FakeHandler) Name() string {
-	return "fake"
-}
-
-func newFakeHandler() handler.Handler {
-	return &FakeHandler{}
-}
 
 var _ = Describe("v1 history resource", func() {
 
@@ -81,8 +64,9 @@ var _ = Describe("v1 history resource", func() {
 			path := fmt.Sprintf("/v1/revision/%s", kv.LabelID)
 			r, _ := http.NewRequest("GET", path, nil)
 			revision := &v1.HistoryResource{}
-			handler.RegisterHandler("fake", newFakeHandler)
-			chain, _ := handler.CreateChain(common.Provider, "testRevisions", "fake")
+			// handler.RegisterHandler("fake", newFakeHandler)
+			// chain, _ := handler.CreateChain(common.Provider, "testRevisions", "auth-handler")
+			chain, _ := handler.GetChain(common.Provider, "")
 			c, err := restfultest.New(revision, chain)
 			It("should not return err or nil", func() {
 				Expect(err).Should(BeNil())

--- a/server/resource/v1/history_resource_test.go
+++ b/server/resource/v1/history_resource_test.go
@@ -64,8 +64,6 @@ var _ = Describe("v1 history resource", func() {
 			path := fmt.Sprintf("/v1/revision/%s", kv.LabelID)
 			r, _ := http.NewRequest("GET", path, nil)
 			revision := &v1.HistoryResource{}
-			// handler.RegisterHandler("fake", newFakeHandler)
-			// chain, _ := handler.CreateChain(common.Provider, "testRevisions", "auth-handler")
 			chain, _ := handler.GetChain(common.Provider, "")
 			c, err := restfultest.New(revision, chain)
 			It("should not return err or nil", func() {

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -20,14 +20,15 @@ package v1
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/apache/servicecomb-kie/pkg/common"
 	"github.com/apache/servicecomb-kie/pkg/model"
 	"github.com/apache/servicecomb-kie/server/db"
-	"github.com/apache/servicecomb-kie/server/service/kv"
+	kvsvc "github.com/apache/servicecomb-kie/server/service/kv"
 	goRestful "github.com/emicklei/go-restful"
 	"github.com/go-chassis/go-chassis/server/restful"
 	"github.com/go-mesh/openlogging"
-	"net/http"
 )
 
 //KVResource has API about kv operations

--- a/server/resource/v1/kv_resource_test.go
+++ b/server/resource/v1/kv_resource_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/servicecomb-kie/pkg/model"
 	"github.com/apache/servicecomb-kie/server/config"
 	"github.com/apache/servicecomb-kie/server/db"
+	noop "github.com/apache/servicecomb-kie/server/handler"
 	v1 "github.com/apache/servicecomb-kie/server/resource/v1"
 )
 
@@ -41,21 +42,23 @@ var _ = Describe("v1 kv resource", func() {
 	config.Configurations = &config.Config{
 		DB: config.DB{},
 	}
-	config.Configurations.DB.URI = "mongodb://kie:123@127.0.0.1:27017"
-	err := db.Init()
-	It("should not return err", func() {
-		Expect(err).Should(BeNil())
-	})
+
 	Describe("put kv", func() {
+		config.Configurations.DB.URI = "mongodb://kie:123@127.0.0.1:27017"
+		err := db.Init()
+		It("should not return err", func() {
+			Expect(err).Should(BeNil())
+		})
 		Context("valid param", func() {
 			kv := &model.KVDoc{
+				Key:    "timeout",
 				Value:  "1s",
 				Labels: map[string]string{"service": "tester"},
 			}
 			j, _ := json.Marshal(kv)
 			r, _ := http.NewRequest("PUT", "/v1/kv/timeout", bytes.NewBuffer(j))
-			handler.RegisterHandler("fake", newFakeHandler)
-			chain, _ := handler.CreateChain(common.Provider, "testchain1", "fake")
+			noopH := &noop.NoopAuthHandler{}
+			chain, _ := handler.CreateChain(common.Provider, "testchain1", noopH.Name())
 			r.Header.Set("Content-Type", "application/json")
 			kvr := &v1.KVResource{}
 			c, err := restfultest.New(kvr, chain)

--- a/swagger/servicecomb-kie.yaml
+++ b/swagger/servicecomb-kie.yaml
@@ -9,88 +9,91 @@ paths:
       summary: search key values by labels combination
       operationId: SearchByLabels
       parameters:
-      - name: q
-        in: query
-        description: 'the combination format is {label_key}:{label_value}+{label_key}:{label_value}
-          for example: /v1/kv?q=app:mall&q=app:mall+service:cart that will query key
-          values from 2 kinds of labels'
-        type: string
+        - name: q
+          in: query
+          description:
+            "the combination format is {label_key}:{label_value}+{label_key}:{label_value}
+            for example: /v1/kv?q=app:mall&q=app:mall+service:cart that will query key
+            values from 2 kinds of labels"
+          type: string
       consumes:
-      - application/json
+        - application/json
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: get key value success
           schema:
             type: array
             items:
-              $ref: '#/definitions/KVResponse'
+              $ref: "#/definitions/KVResponse"
   /v1/kv/{key}:
     get:
       summary: get key values by key and labels
       operationId: GetByKey
       parameters:
-      - name: key
-        in: path
-        required: true
-        type: string
-      - name: X-Depth
-        in: header
-        description: integer, default is 1, if you set match policy, you can set,depth
-          to decide label number
-        type: string
-      - name: body
-        in: body
-        required: true
-        schema:
-          $ref: '#/definitions/*v1.KVBody'
+        - name: key
+          in: path
+          required: true
+          type: string
+        - name: X-Depth
+          in: header
+          description:
+            integer, default is 1, if you set match policy, you can set,depth
+            to decide label number
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/*v1.KVBody"
       consumes:
-      - application/json
+        - application/json
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: get key value success
           schema:
             type: array
             items:
-              $ref: '#/definitions/KVResponse'
+              $ref: "#/definitions/KVResponse"
     put:
       summary: create or update key value
       operationId: Put
       parameters:
-      - name: key
-        in: path
-        required: true
-        type: string
-      - name: X-Realm
-        in: header
-        description: set kv to heterogeneous config server, not implement yet
-        type: string
-      - name: body
-        in: body
-        required: true
-        schema:
-          $ref: '#/definitions/v1.KVBody'
+        - name: key
+          in: path
+          required: true
+          type: string
+        - name: X-Realm
+          in: header
+          description: set kv to heterogeneous config server, not implement yet
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/v1.KVBody"
       consumes:
-      - application/json
+        - application/json
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: "true"
   /v1/kv/{kvID}:
     delete:
-      summary: Delete key by kvID and labelID,If the labelID is nil, query the collection
+      summary:
+        Delete key by kvID and labelID,If the labelID is nil, query the collection
         kv to get it.It means if only get kvID, it can also delete normally.But if
         you want better performance, you need to pass the labelID
       operationId: Delete
       parameters:
-      - name: key
-        in: path
-        required: true
-        type: string
+        - name: key
+          in: path
+          required: true
+          type: string
       responses:
         "204":
           description: Delete success
@@ -132,9 +135,9 @@ definitions:
       data:
         type: array
         items:
-          $ref: '#/definitions/KVDoc'
+          $ref: "#/definitions/KVDoc"
       label:
-        $ref: '#/definitions/LabelDocResponse'
+        $ref: "#/definitions/LabelDocResponse"
   LabelDocResponse:
     type: object
     properties:


### PR DESCRIPTION
1. add getHistoryByLabelID interface along with unit test. also modify some existing interfaces and test since we have updated go-restful for api tests
2. new interface fit new dao structure
3. modify some doc fields for history interfaces implementation