### PR TITLE
SCB-1723 support pagination in kie apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ release
 etc/data/
 etc/ssl/
 tmp/
+conf/
 glide.lock

--- a/docs/configurations/storage.md
+++ b/docs/configurations/storage.md
@@ -20,7 +20,7 @@ you can use mongo db as kie server storage to save configuration
 ### Example
 ```yaml
 db:
-  uri: mongodb://kie:123@127.0.0.1:27017
+  uri: mongodb://kie:123@127.0.0.1:27017/kie
   poolSize: 10
   timeout:  5m
   sslEnabled: true

--- a/examples/dev/db.js
+++ b/examples/dev/db.js
@@ -48,3 +48,4 @@ db.createCollection( "kv", {
 } );
 db.kv.createIndex({"id": 1}, { unique: true } );
 db.kv.createIndex({key: 1, label_id: 1,domain:1,project:1},{ unique: true });
+db.setProfilingLevel(1, {slowms: 80, sampleRate: 1} );

--- a/examples/dev/kie-conf.yaml
+++ b/examples/dev/kie-conf.yaml
@@ -1,6 +1,6 @@
 db:
   #uri: mongodb://rwuser:xxx@x.x.x.x:8635/test?authSource=admin
-  uri: mongodb://kie:123@127.0.0.1:27017
+  uri: mongodb://kie:123@127.0.0.1:27017/kie
   type: mongodb
   poolSize: 10
   timeout:  5m

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -25,6 +25,8 @@ const (
 	QueryParamRev    = "revision"
 	QueryParamMatch  = "match"
 	QueryParamKeyID  = "kv_id"
+	QueryLimit       = "limit"
+	QueryOffset      = "offset"
 )
 
 //http headers

--- a/server/resource/v1/common.go
+++ b/server/resource/v1/common.go
@@ -212,7 +212,7 @@ func checkPagination(limitStr, offsetStr string) (int64, int64, error) {
 	return limit, offset, err
 }
 func queryAndResponse(rctx *restful.Context,
-	domain interface{}, project string, key string, labels map[string]string, limit, offset int) {
+	domain interface{}, project string, key string, labels map[string]string, limit, offset int64) {
 	m := getMatchPattern(rctx)
 	opts := []service.FindOption{service.WithKey(key), service.WithLabels(labels)}
 	if m == PatternExact {

--- a/server/resource/v1/common.go
+++ b/server/resource/v1/common.go
@@ -214,12 +214,16 @@ func checkPagination(limitStr, offsetStr string) (int64, int64, error) {
 func queryAndResponse(rctx *restful.Context,
 	domain interface{}, project string, key string, labels map[string]string, limit, offset int64) {
 	m := getMatchPattern(rctx)
-	opts := []service.FindOption{service.WithKey(key), service.WithLabels(labels)}
+	opts := []service.FindOption{
+		service.WithKey(key),
+		service.WithLabels(labels),
+		service.WithLimit(limit),
+		service.WithOffset(offset),
+	}
 	if m == PatternExact {
 		opts = append(opts, service.WithExactLabels())
 	}
-	kv, err := service.KVService.List(rctx.Ctx, domain.(string), project,
-		limit, offset, opts...)
+	kv, err := service.KVService.List(rctx.Ctx, domain.(string), project, opts...)
 	if err != nil {
 		if err == service.ErrKeyNotExists {
 			WriteErrResponse(rctx, http.StatusNotFound, err.Error(), common.ContentTypeText)

--- a/server/resource/v1/common.go
+++ b/server/resource/v1/common.go
@@ -205,7 +205,7 @@ func checkPagination(limitStr, offsetStr string) (int64, int64, error) {
 		if err != nil {
 			return 0, 0, errors.New("invalid offset number")
 		}
-		if offset < 1 {
+		if offset < 0 {
 			return 0, 0, errors.New("invalid offset number")
 		}
 	}

--- a/server/resource/v1/doc_struct.go
+++ b/server/resource/v1/doc_struct.go
@@ -89,6 +89,18 @@ var (
 		ParamType: goRestful.QueryParameterKind,
 		Desc:      "label pairs,for example &label=service:order&label=version:1.0.0",
 	}
+	DocQueryLimitParameters = &restful.Parameters{
+		DataType:  "string",
+		Name:      common.QueryLimit,
+		ParamType: goRestful.QueryParameterKind,
+		Desc:      "limit,for example &limit=10",
+	}
+	DocQueryOffsetParameters = &restful.Parameters{
+		DataType:  "string",
+		Name:      common.QueryOffset,
+		ParamType: goRestful.QueryParameterKind,
+		Desc:      "offset,for example &offset=10",
+	}
 )
 
 //swagger doc path params

--- a/server/resource/v1/history_resource.go
+++ b/server/resource/v1/history_resource.go
@@ -36,21 +36,21 @@ type HistoryResource struct {
 //GetRevisions search key only by label
 func (r *HistoryResource) GetRevisions(context *restful.Context) {
 	var err error
-	labelID := context.ReadPathParameter("key_id")
-	limitStr := context.ReadPathParameter("limit")
-	offsetStr := context.ReadPathParameter("offset")
+	keyID := context.ReadPathParameter("key_id")
+	limitStr := context.ReadQueryParameter("limit")
+	offsetStr := context.ReadQueryParameter("offset")
 	limit, offset, err := checkPagination(limitStr, offsetStr)
 	if err != nil {
 		WriteErrResponse(context, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	if labelID == "" {
+	if keyID == "" {
 		openlogging.Error("key id is nil")
 		WriteErrResponse(context, http.StatusForbidden, "key_id must not be empty", common.ContentTypeText)
 		return
 	}
 	key := context.ReadQueryParameter("key")
-	revisions, err := service.HistoryService.GetHistory(context.Ctx, labelID,
+	revisions, err := service.HistoryService.GetHistory(context.Ctx, keyID,
 		service.WithKey(key),
 		service.WithLimit(limit),
 		service.WithOffset(offset))

--- a/server/resource/v1/history_resource.go
+++ b/server/resource/v1/history_resource.go
@@ -50,7 +50,10 @@ func (r *HistoryResource) GetRevisions(context *restful.Context) {
 		return
 	}
 	key := context.ReadQueryParameter("key")
-	revisions, err := service.HistoryService.GetHistory(context.Ctx, labelID, limit, offset, service.WithKey(key))
+	revisions, err := service.HistoryService.GetHistory(context.Ctx, labelID,
+		service.WithKey(key),
+		service.WithLimit(limit),
+		service.WithOffset(offset))
 	if err != nil {
 		if err == service.ErrRevisionNotExist {
 			WriteErrResponse(context, http.StatusNotFound, err.Error(), common.ContentTypeText)

--- a/server/resource/v1/history_resource.go
+++ b/server/resource/v1/history_resource.go
@@ -37,13 +37,20 @@ type HistoryResource struct {
 func (r *HistoryResource) GetRevisions(context *restful.Context) {
 	var err error
 	labelID := context.ReadPathParameter("key_id")
+	limitStr := context.ReadPathParameter("limit")
+	offsetStr := context.ReadPathParameter("offset")
+	limit, offset, err := checkPagination(limitStr, offsetStr)
+	if err != nil {
+		WriteErrResponse(context, http.StatusBadRequest, err.Error(), common.ContentTypeText)
+		return
+	}
 	if labelID == "" {
 		openlogging.Error("key id is nil")
 		WriteErrResponse(context, http.StatusForbidden, "key_id must not be empty", common.ContentTypeText)
 		return
 	}
 	key := context.ReadQueryParameter("key")
-	revisions, err := service.HistoryService.GetHistory(context.Ctx, labelID, service.WithKey(key))
+	revisions, err := service.HistoryService.GetHistory(context.Ctx, labelID, limit, offset, service.WithKey(key))
 	if err != nil {
 		if err == service.ErrRevisionNotExist {
 			WriteErrResponse(context, http.StatusNotFound, err.Error(), common.ContentTypeText)

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -209,7 +209,9 @@ func (r *KVResource) Search(context *restful.Context) {
 		return
 	}
 	if labelCombinations == nil {
-		result, err := service.KVService.FindKV(context.Ctx, domain.(string), project, limit, offset)
+		result, err := service.KVService.FindKV(context.Ctx, domain.(string), project,
+			service.WithLimit(limit),
+			service.WithOffset(offset))
 		if err != nil {
 			openlogging.Error("can not find by labels", openlogging.WithTags(openlogging.Tags{
 				"err": err.Error(),
@@ -223,7 +225,10 @@ func (r *KVResource) Search(context *restful.Context) {
 		openlogging.Debug("find by combination", openlogging.WithTags(openlogging.Tags{
 			"q": labels,
 		}))
-		result, err := service.KVService.FindKV(context.Ctx, domain.(string), project, limit, offset, service.WithLabels(labels))
+		result, err := service.KVService.FindKV(context.Ctx, domain.(string), project,
+			service.WithLabels(labels),
+			service.WithLimit(limit),
+			service.WithOffset(offset))
 		if err != nil {
 			if err == service.ErrKeyNotExists {
 				continue

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -96,8 +96,8 @@ func (r *KVResource) GetByKey(rctx *restful.Context) {
 		WriteErrResponse(rctx, http.StatusInternalServerError, MsgDomainMustNotBeEmpty, common.ContentTypeText)
 		return
 	}
-	limitStr := rctx.ReadPathParameter("limit")
-	offsetStr := rctx.ReadPathParameter("offset")
+	limitStr := rctx.ReadQueryParameter("limit")
+	offsetStr := rctx.ReadQueryParameter("offset")
 	limit, offset, err := checkPagination(limitStr, offsetStr)
 	if err != nil {
 		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
@@ -119,8 +119,8 @@ func (r *KVResource) List(rctx *restful.Context) {
 		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	limitStr := rctx.ReadPathParameter("limit")
-	offsetStr := rctx.ReadPathParameter("offset")
+	limitStr := rctx.ReadQueryParameter("limit")
+	offsetStr := rctx.ReadQueryParameter("offset")
 	limit, offset, err := checkPagination(limitStr, offsetStr)
 	if err != nil {
 		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
@@ -201,8 +201,8 @@ func (r *KVResource) Search(context *restful.Context) {
 		return
 	}
 	var kvs []*model.KVResponse
-	limitStr := context.ReadPathParameter("limit")
-	offsetStr := context.ReadPathParameter("offset")
+	limitStr := context.ReadQueryParameter("limit")
+	offsetStr := context.ReadQueryParameter("offset")
 	limit, offset, err := checkPagination(limitStr, offsetStr)
 	if err != nil {
 		WriteErrResponse(context, http.StatusBadRequest, err.Error(), common.ContentTypeText)

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -96,10 +96,16 @@ func (r *KVResource) GetByKey(rctx *restful.Context) {
 		WriteErrResponse(rctx, http.StatusInternalServerError, MsgDomainMustNotBeEmpty, common.ContentTypeText)
 		return
 	}
-	returnData(rctx, domain, project, labels, 0, 0)
+	limitStr := rctx.ReadPathParameter("limit")
+	offsetStr := rctx.ReadPathParameter("offset")
+	limit, offset, err := checkPagination(limitStr, offsetStr)
+	if err != nil {
+		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
+		return
+	}
+	returnData(rctx, domain, project, labels, limit, offset)
 }
 
-//List TODO pagination
 func (r *KVResource) List(rctx *restful.Context) {
 	var err error
 	project := rctx.ReadPathParameter("project")
@@ -123,12 +129,12 @@ func (r *KVResource) List(rctx *restful.Context) {
 	returnData(rctx, domain, project, labels, limit, offset)
 }
 
-func returnData(rctx *restful.Context, domain interface{}, project string, labels map[string]string, limit int64, offset int64) {
+func returnData(rctx *restful.Context, domain interface{}, project string, labels map[string]string, limit, offset int64) {
 	revStr := rctx.ReadQueryParameter(common.QueryParamRev)
 	wait := rctx.ReadQueryParameter(common.QueryParamWait)
 	if revStr == "" {
 		if wait == "" {
-			queryAndResponse(rctx, domain, project, "", labels, int(limit), int(offset))
+			queryAndResponse(rctx, domain, project, "", labels, limit, offset)
 			return
 		}
 		changed, err := eventHappened(rctx, wait, &pubsub.Topic{
@@ -141,7 +147,7 @@ func returnData(rctx *restful.Context, domain interface{}, project string, label
 			return
 		}
 		if changed {
-			queryAndResponse(rctx, domain, project, "", labels, int(limit), int(offset))
+			queryAndResponse(rctx, domain, project, "", labels, limit, offset)
 			return
 		}
 		rctx.WriteHeader(http.StatusNotModified)
@@ -156,7 +162,7 @@ func returnData(rctx *restful.Context, domain interface{}, project string, label
 			return
 		}
 		if revised {
-			queryAndResponse(rctx, domain, project, "", labels, int(limit), int(offset))
+			queryAndResponse(rctx, domain, project, "", labels, limit, offset)
 			return
 		} else if wait != "" {
 			changed, err := eventHappened(rctx, wait, &pubsub.Topic{
@@ -169,7 +175,7 @@ func returnData(rctx *restful.Context, domain interface{}, project string, label
 				return
 			}
 			if changed {
-				queryAndResponse(rctx, domain, project, "", labels, int(limit), int(offset))
+				queryAndResponse(rctx, domain, project, "", labels, limit, offset)
 				return
 			}
 			rctx.WriteHeader(http.StatusNotModified)
@@ -195,8 +201,15 @@ func (r *KVResource) Search(context *restful.Context) {
 		return
 	}
 	var kvs []*model.KVResponse
+	limitStr := context.ReadPathParameter("limit")
+	offsetStr := context.ReadPathParameter("offset")
+	limit, offset, err := checkPagination(limitStr, offsetStr)
+	if err != nil {
+		WriteErrResponse(context, http.StatusBadRequest, err.Error(), common.ContentTypeText)
+		return
+	}
 	if labelCombinations == nil {
-		result, err := service.KVService.FindKV(context.Ctx, domain.(string), project)
+		result, err := service.KVService.FindKV(context.Ctx, domain.(string), project, limit, offset)
 		if err != nil {
 			openlogging.Error("can not find by labels", openlogging.WithTags(openlogging.Tags{
 				"err": err.Error(),
@@ -210,7 +223,7 @@ func (r *KVResource) Search(context *restful.Context) {
 		openlogging.Debug("find by combination", openlogging.WithTags(openlogging.Tags{
 			"q": labels,
 		}))
-		result, err := service.KVService.FindKV(context.Ctx, domain.(string), project, service.WithLabels(labels))
+		result, err := service.KVService.FindKV(context.Ctx, domain.(string), project, limit, offset, service.WithLabels(labels))
 		if err != nil {
 			if err == service.ErrKeyNotExists {
 				continue

--- a/server/resource/v1/kv_resource_test.go
+++ b/server/resource/v1/kv_resource_test.go
@@ -56,7 +56,7 @@ func init() {
 		ListenPeerAddr: "127.0.0.1:4000",
 		AdvertiseAddr:  "127.0.0.1:4000",
 	}
-	config.Configurations.DB.URI = "mongodb://kie:123@127.0.0.1:27017"
+	config.Configurations.DB.URI = "mongodb://kie:123@127.0.0.1:27017/kie"
 	err := service.DBInit()
 	if err != nil {
 		panic(err)

--- a/server/resource/v1/kv_resource_test.go
+++ b/server/resource/v1/kv_resource_test.go
@@ -220,6 +220,40 @@ func TestKVResource_List(t *testing.T) {
 		duration := time.Since(start)
 		t.Log(duration)
 	})
+	t.Run("list kv by service label offset, should return 1kv", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "/v1/test/kie/kv?label=service:utService&offset=1", nil)
+		noopH := &handler2.NoopAuthHandler{}
+		chain, _ := handler.CreateChain(common.Provider, "testchain1", noopH.Name())
+		r.Header.Set("Content-Type", "application/json")
+		kvr := &v1.KVResource{}
+		c, err := restfultest.New(kvr, chain)
+		assert.NoError(t, err)
+		resp := httptest.NewRecorder()
+		c.ServeHTTP(resp, r)
+		body, err := ioutil.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		result := &model.KVResponse{}
+		err = json.Unmarshal(body, result)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result.Data))
+	})
+	t.Run("list kv by service label limit, should return 1kv", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "/v1/test/kie/kv?label=service:utService&limit=1", nil)
+		noopH := &handler2.NoopAuthHandler{}
+		chain, _ := handler.CreateChain(common.Provider, "testchain1", noopH.Name())
+		r.Header.Set("Content-Type", "application/json")
+		kvr := &v1.KVResource{}
+		c, err := restfultest.New(kvr, chain)
+		assert.NoError(t, err)
+		resp := httptest.NewRecorder()
+		c.ServeHTTP(resp, r)
+		body, err := ioutil.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		result := &model.KVResponse{}
+		err = json.Unmarshal(body, result)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result.Data))
+	})
 }
 func TestKVResource_GetByKey(t *testing.T) {
 	t.Run("get one key by label, exact match,should return 1 kv", func(t *testing.T) {

--- a/server/service/mongo/counter/revision_test.go
+++ b/server/service/mongo/counter/revision_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestIncreaseAndGetRevision(t *testing.T) {
 	var err error
-	config.Configurations = &config.Config{DB: config.DB{URI: "mongodb://kie:123@127.0.0.1:27017"}}
+	config.Configurations = &config.Config{DB: config.DB{URI: "mongodb://kie:123@127.0.0.1:27017/kie"}}
 	err = session.Init()
 	assert.NoError(t, err)
 	s := &counter.Service{}

--- a/server/service/mongo/history/dao.go
+++ b/server/service/mongo/history/dao.go
@@ -31,7 +31,7 @@ func getHistoryByKeyID(ctx context.Context, filter bson.M, limit, offset int64) 
 	collection := session.GetDB().Collection(session.CollectionKVRevision)
 	cur, err := collection.Find(ctx, filter, options.Find().SetSort(map[string]interface{}{
 		"revision": -1,
-	}).SetSkip(offset*limit).SetLimit(limit))
+	}).SetSkip(offset).SetLimit(limit))
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/mongo/history/dao.go
+++ b/server/service/mongo/history/dao.go
@@ -29,9 +29,16 @@ import (
 
 func getHistoryByKeyID(ctx context.Context, filter bson.M, limit, offset int64) ([]*model.KVDoc, error) {
 	collection := session.GetDB().Collection(session.CollectionKVRevision)
-	cur, err := collection.Find(ctx, filter, options.Find().SetSort(map[string]interface{}{
+	opt := options.Find().SetSort(map[string]interface{}{
 		"revision": -1,
-	}).SetSkip(offset).SetLimit(limit))
+	})
+	if limit != 0 {
+		opt = opt.SetLimit(limit)
+	}
+	if offset != 0 {
+		opt = opt.SetSkip(offset)
+	}
+	cur, err := collection.Find(ctx, filter, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/mongo/history/dao.go
+++ b/server/service/mongo/history/dao.go
@@ -27,11 +27,11 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func getHistoryByKeyID(ctx context.Context, filter bson.M) ([]*model.KVDoc, error) {
+func getHistoryByKeyID(ctx context.Context, filter bson.M, limit, offset int64) ([]*model.KVDoc, error) {
 	collection := session.GetDB().Collection(session.CollectionKVRevision)
 	cur, err := collection.Find(ctx, filter, options.Find().SetSort(map[string]interface{}{
 		"revision": -1,
-	}))
+	}).SetSkip(offset*limit).SetLimit(limit))
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/mongo/history/service.go
+++ b/server/service/mongo/history/service.go
@@ -30,7 +30,7 @@ type Service struct {
 }
 
 //GetHistory get all history by label id
-func (s *Service) GetHistory(ctx context.Context, kvID string, limit, offset int64, options ...service.FindOption) ([]*model.KVDoc, error) {
+func (s *Service) GetHistory(ctx context.Context, kvID string, options ...service.FindOption) ([]*model.KVDoc, error) {
 	var filter primitive.M
 	opts := service.FindOptions{}
 	for _, o := range options {
@@ -40,5 +40,5 @@ func (s *Service) GetHistory(ctx context.Context, kvID string, limit, offset int
 		"id": kvID,
 	}
 
-	return getHistoryByKeyID(ctx, filter, limit, offset)
+	return getHistoryByKeyID(ctx, filter, opts.Limit, opts.Offset)
 }

--- a/server/service/mongo/history/service.go
+++ b/server/service/mongo/history/service.go
@@ -30,7 +30,7 @@ type Service struct {
 }
 
 //GetHistory get all history by label id
-func (s *Service) GetHistory(ctx context.Context, kvID string, options ...service.FindOption) ([]*model.KVDoc, error) {
+func (s *Service) GetHistory(ctx context.Context, kvID string, limit, offset int64, options ...service.FindOption) ([]*model.KVDoc, error) {
 	var filter primitive.M
 	opts := service.FindOptions{}
 	for _, o := range options {
@@ -40,5 +40,5 @@ func (s *Service) GetHistory(ctx context.Context, kvID string, options ...servic
 		"id": kvID,
 	}
 
-	return getHistoryByKeyID(ctx, filter)
+	return getHistoryByKeyID(ctx, filter, limit, offset)
 }

--- a/server/service/mongo/history/service_test.go
+++ b/server/service/mongo/history/service_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	config.Configurations = &config.Config{DB: config.DB{URI: "mongodb://kie:123@127.0.0.1:27017"}}
+	config.Configurations = &config.Config{DB: config.DB{URI: "mongodb://kie:123@127.0.0.1:27017/kie"}}
 	_ = session.Init()
 }
 

--- a/server/service/mongo/kv/kv_dao.go
+++ b/server/service/mongo/kv/kv_dao.go
@@ -112,7 +112,14 @@ func findKV(ctx context.Context, domain string, project string, opts service.Fin
 			filter["labels."+k] = v
 		}
 	}
-	cur, err := collection.Find(ctx, filter, options.Find().SetSkip(opts.Offset).SetLimit(opts.Limit))
+	opt := options.Find()
+	if opts.Limit != 0 {
+		opt = opt.SetLimit(opts.Limit)
+	}
+	if opts.Offset != 0 {
+		opt = opt.SetSkip(opts.Offset)
+	}
+	cur, err := collection.Find(ctx, filter, opt)
 	if err != nil {
 		if err.Error() == context.DeadlineExceeded.Error() {
 			openlogging.Error("find kv failed, deadline exceeded", openlogging.WithTags(openlogging.Tags{

--- a/server/service/mongo/kv/kv_dao.go
+++ b/server/service/mongo/kv/kv_dao.go
@@ -100,7 +100,7 @@ func updateKeyValue(ctx context.Context, kv *model.KVDoc) error {
 
 }
 
-func findKV(ctx context.Context, domain string, project string, opts service.FindOptions, limit, offset int64) (*mongo.Cursor, error) {
+func findKV(ctx context.Context, domain string, project string, opts service.FindOptions) (*mongo.Cursor, error) {
 	collection := session.GetDB().Collection(session.CollectionKV)
 	ctx, _ = context.WithTimeout(ctx, opts.Timeout)
 	filter := bson.M{"domain": domain, "project": project}
@@ -112,7 +112,7 @@ func findKV(ctx context.Context, domain string, project string, opts service.Fin
 			filter["labels."+k] = v
 		}
 	}
-	cur, err := collection.Find(ctx, filter, options.Find().SetSkip(offset*limit).SetLimit(limit))
+	cur, err := collection.Find(ctx, filter, options.Find().SetSkip(opts.Offset).SetLimit(opts.Limit))
 	if err != nil {
 		if err.Error() == context.DeadlineExceeded.Error() {
 			openlogging.Error("find kv failed, deadline exceeded", openlogging.WithTags(openlogging.Tags{

--- a/server/service/mongo/kv/kv_service.go
+++ b/server/service/mongo/kv/kv_service.go
@@ -110,7 +110,7 @@ func (s *Service) Exist(ctx context.Context, domain, key string, project string,
 		}
 		return kvs[0], nil
 	}
-	kvs, err := s.FindKV(ctx, domain, project,
+	kvs, err := s.FindKV(ctx, domain, project, 2, 0,
 		service.WithExactLabels(), service.WithLabels(opts.Labels), service.WithKey(key))
 	if err != nil {
 		openlogging.Error(err.Error())
@@ -147,12 +147,12 @@ func (s *Service) Delete(ctx context.Context, kvID string, domain string, projec
 }
 
 //List get kv list by key and criteria
-func (s *Service) List(ctx context.Context, domain, project string, limit, offset int, options ...service.FindOption) (*model.KVResponse, error) {
+func (s *Service) List(ctx context.Context, domain, project string, limit, offset int64, options ...service.FindOption) (*model.KVResponse, error) {
 	opts := service.NewDefaultFindOpts()
 	for _, o := range options {
 		o(&opts)
 	}
-	cur, err := findKV(ctx, domain, project, opts)
+	cur, err := findKV(ctx, domain, project, opts, limit, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (s *Service) List(ctx context.Context, domain, project string, limit, offse
 //FindKV get kvs by key, labels
 //because labels has a a lot of combination,
 //you can use WithDepth(0) to return only one kv which's labels exactly match the criteria
-func (s *Service) FindKV(ctx context.Context, domain string, project string, options ...service.FindOption) ([]*model.KVResponse, error) {
+func (s *Service) FindKV(ctx context.Context, domain string, project string, limit, offset int64, options ...service.FindOption) ([]*model.KVResponse, error) {
 	opts := service.FindOptions{}
 	for _, o := range options {
 		o(&opts)
@@ -196,7 +196,7 @@ func (s *Service) FindKV(ctx context.Context, domain string, project string, opt
 		return nil, session.ErrMissingProject
 	}
 
-	cur, err := findKV(ctx, domain, project, opts)
+	cur, err := findKV(ctx, domain, project, opts, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/mongo/kv/kv_test.go
+++ b/server/service/mongo/kv/kv_test.go
@@ -81,7 +81,7 @@ func TestService_CreateOrUpdate(t *testing.T) {
 			Project: "test",
 		})
 		assert.NoError(t, err)
-		kvs1, err := kvsvc.FindKV(context.Background(), "default", "test", service.WithKey("timeout"), service.WithLabels(map[string]string{
+		kvs1, err := kvsvc.FindKV(context.Background(), "default", "test", 10, 0, service.WithKey("timeout"), service.WithLabels(map[string]string{
 			"app": "mall",
 		}), service.WithExactLabels())
 		assert.Equal(t, beforeKV.Value, kvs1[0].Data[0].Value)
@@ -99,7 +99,7 @@ func TestService_CreateOrUpdate(t *testing.T) {
 			"app": "mall",
 		}))
 		assert.Equal(t, beforeKV.ID, savedKV.ID)
-		kvs, err := kvsvc.FindKV(context.Background(), "default", "test", service.WithKey("timeout"), service.WithLabels(map[string]string{
+		kvs, err := kvsvc.FindKV(context.Background(), "default", "test", 10, 0, service.WithKey("timeout"), service.WithLabels(map[string]string{
 			"app": "mall",
 		}), service.WithExactLabels())
 		assert.Equal(t, afterKV.Value, kvs[0].Data[0].Value)
@@ -110,7 +110,7 @@ func TestService_CreateOrUpdate(t *testing.T) {
 func TestService_FindKV(t *testing.T) {
 	kvsvc := &kv.Service{}
 	t.Run("exact find by kv and labels with label app", func(t *testing.T) {
-		kvs, err := kvsvc.FindKV(context.Background(), "default", "test",
+		kvs, err := kvsvc.FindKV(context.Background(), "default", "test", 10, 0,
 			service.WithKey("timeout"),
 			service.WithLabels(map[string]string{
 				"app": "mall",
@@ -120,7 +120,7 @@ func TestService_FindKV(t *testing.T) {
 		assert.Equal(t, 1, len(kvs))
 	})
 	t.Run("greedy find by labels,with labels app ans service ", func(t *testing.T) {
-		kvs, err := kvsvc.FindKV(context.Background(), "default", "test", service.WithLabels(map[string]string{
+		kvs, err := kvsvc.FindKV(context.Background(), "default", "test", 10, 0, service.WithLabels(map[string]string{
 			"app":     "mall",
 			"service": "cart",
 		}))

--- a/server/service/mongo/kv/kv_test.go
+++ b/server/service/mongo/kv/kv_test.go
@@ -28,12 +28,6 @@ import (
 	"testing"
 )
 
-//const
-const (
-	defaultLimit  = 10
-	defaultOffset = 0
-)
-
 func TestService_CreateOrUpdate(t *testing.T) {
 	var err error
 	config.Configurations = &config.Config{DB: config.DB{URI: "mongodb://kie:123@127.0.0.1:27017/kie"}}
@@ -92,9 +86,7 @@ func TestService_CreateOrUpdate(t *testing.T) {
 			service.WithLabels(map[string]string{
 				"app": "mall",
 			}),
-			service.WithExactLabels(),
-			service.WithLimit(defaultLimit),
-			service.WithOffset(defaultOffset))
+			service.WithExactLabels())
 		assert.Equal(t, beforeKV.Value, kvs1[0].Data[0].Value)
 		afterKV, err := kvsvc.CreateOrUpdate(context.Background(), &model.KVDoc{
 			Key:   "timeout",
@@ -115,9 +107,7 @@ func TestService_CreateOrUpdate(t *testing.T) {
 			service.WithLabels(map[string]string{
 				"app": "mall",
 			}),
-			service.WithExactLabels(),
-			service.WithLimit(defaultLimit),
-			service.WithOffset(defaultOffset))
+			service.WithExactLabels())
 		assert.Equal(t, afterKV.Value, kvs[0].Data[0].Value)
 	})
 
@@ -131,9 +121,7 @@ func TestService_FindKV(t *testing.T) {
 			service.WithLabels(map[string]string{
 				"app": "mall",
 			}),
-			service.WithExactLabels(),
-			service.WithLimit(defaultLimit),
-			service.WithOffset(defaultOffset))
+			service.WithExactLabels())
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(kvs))
 	})
@@ -142,9 +130,7 @@ func TestService_FindKV(t *testing.T) {
 			service.WithLabels(map[string]string{
 				"app":     "mall",
 				"service": "cart",
-			}),
-			service.WithLimit(defaultLimit),
-			service.WithOffset(defaultOffset))
+			}))
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(kvs))
 	})

--- a/server/service/mongo/kv/kv_test.go
+++ b/server/service/mongo/kv/kv_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestService_CreateOrUpdate(t *testing.T) {
 	var err error
-	config.Configurations = &config.Config{DB: config.DB{URI: "mongodb://kie:123@127.0.0.1:27017"}}
+	config.Configurations = &config.Config{DB: config.DB{URI: "mongodb://kie:123@127.0.0.1:27017/kie"}}
 	err = session.Init()
 	assert.NoError(t, err)
 	kvsvc := &kv.Service{}

--- a/server/service/mongo/kv/kv_test.go
+++ b/server/service/mongo/kv/kv_test.go
@@ -28,6 +28,12 @@ import (
 	"testing"
 )
 
+//const
+const (
+	defaultLimit  = 10
+	defaultOffset = 0
+)
+
 func TestService_CreateOrUpdate(t *testing.T) {
 	var err error
 	config.Configurations = &config.Config{DB: config.DB{URI: "mongodb://kie:123@127.0.0.1:27017/kie"}}
@@ -81,9 +87,14 @@ func TestService_CreateOrUpdate(t *testing.T) {
 			Project: "test",
 		})
 		assert.NoError(t, err)
-		kvs1, err := kvsvc.FindKV(context.Background(), "default", "test", 10, 0, service.WithKey("timeout"), service.WithLabels(map[string]string{
-			"app": "mall",
-		}), service.WithExactLabels())
+		kvs1, err := kvsvc.FindKV(context.Background(), "default", "test",
+			service.WithKey("timeout"),
+			service.WithLabels(map[string]string{
+				"app": "mall",
+			}),
+			service.WithExactLabels(),
+			service.WithLimit(defaultLimit),
+			service.WithOffset(defaultOffset))
 		assert.Equal(t, beforeKV.Value, kvs1[0].Data[0].Value)
 		afterKV, err := kvsvc.CreateOrUpdate(context.Background(), &model.KVDoc{
 			Key:   "timeout",
@@ -99,9 +110,14 @@ func TestService_CreateOrUpdate(t *testing.T) {
 			"app": "mall",
 		}))
 		assert.Equal(t, beforeKV.ID, savedKV.ID)
-		kvs, err := kvsvc.FindKV(context.Background(), "default", "test", 10, 0, service.WithKey("timeout"), service.WithLabels(map[string]string{
-			"app": "mall",
-		}), service.WithExactLabels())
+		kvs, err := kvsvc.FindKV(context.Background(), "default", "test",
+			service.WithKey("timeout"),
+			service.WithLabels(map[string]string{
+				"app": "mall",
+			}),
+			service.WithExactLabels(),
+			service.WithLimit(defaultLimit),
+			service.WithOffset(defaultOffset))
 		assert.Equal(t, afterKV.Value, kvs[0].Data[0].Value)
 	})
 
@@ -110,20 +126,25 @@ func TestService_CreateOrUpdate(t *testing.T) {
 func TestService_FindKV(t *testing.T) {
 	kvsvc := &kv.Service{}
 	t.Run("exact find by kv and labels with label app", func(t *testing.T) {
-		kvs, err := kvsvc.FindKV(context.Background(), "default", "test", 10, 0,
+		kvs, err := kvsvc.FindKV(context.Background(), "default", "test",
 			service.WithKey("timeout"),
 			service.WithLabels(map[string]string{
 				"app": "mall",
 			}),
-			service.WithExactLabels())
+			service.WithExactLabels(),
+			service.WithLimit(defaultLimit),
+			service.WithOffset(defaultOffset))
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(kvs))
 	})
 	t.Run("greedy find by labels,with labels app ans service ", func(t *testing.T) {
-		kvs, err := kvsvc.FindKV(context.Background(), "default", "test", 10, 0, service.WithLabels(map[string]string{
-			"app":     "mall",
-			"service": "cart",
-		}))
+		kvs, err := kvsvc.FindKV(context.Background(), "default", "test",
+			service.WithLabels(map[string]string{
+				"app":     "mall",
+				"service": "cart",
+			}),
+			service.WithLimit(defaultLimit),
+			service.WithOffset(defaultOffset))
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(kvs))
 	})

--- a/server/service/options.go
+++ b/server/service/options.go
@@ -38,6 +38,8 @@ type FindOptions struct {
 	LabelID     string
 	ClearLabel  bool
 	Timeout     time.Duration
+	Limit       int64
+	Offset      int64
 }
 
 //FindOption is functional option to find key value
@@ -89,5 +91,19 @@ func WithDepth(d int) FindOption {
 func WithOutLabelField() FindOption {
 	return func(o *FindOptions) {
 		o.ClearLabel = true
+	}
+}
+
+//WithLimit tells service paging limit
+func WithLimit(l int64) FindOption {
+	return func(o *FindOptions) {
+		o.Limit = l
+	}
+}
+
+//WithOffset tells service paging offset
+func WithOffset(os int64) FindOption {
+	return func(o *FindOptions) {
+		o.Offset = os
 	}
 }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -41,15 +41,15 @@ var (
 type KV interface {
 	//below 3 methods is usually for admin console
 	CreateOrUpdate(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, error)
-	List(ctx context.Context, domain, project string, limit, offset int64, options ...FindOption) (*model.KVResponse, error)
+	List(ctx context.Context, domain, project string, options ...FindOption) (*model.KVResponse, error)
 	Delete(ctx context.Context, kvID string, domain, project string) error
 	//FindKV is usually for service to pull configs
-	FindKV(ctx context.Context, domain, project string, limit, offset int64, options ...FindOption) ([]*model.KVResponse, error)
+	FindKV(ctx context.Context, domain, project string, options ...FindOption) ([]*model.KVResponse, error)
 }
 
 //History provide api of History entity
 type History interface {
-	GetHistory(ctx context.Context, keyID string, limit, offset int64, options ...FindOption) ([]*model.KVDoc, error)
+	GetHistory(ctx context.Context, keyID string, options ...FindOption) ([]*model.KVDoc, error)
 }
 type Revision interface {
 	GetRevision(ctx context.Context) (int64, error)

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -41,15 +41,15 @@ var (
 type KV interface {
 	//below 3 methods is usually for admin console
 	CreateOrUpdate(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, error)
-	List(ctx context.Context, domain, project string, limit, offset int, options ...FindOption) (*model.KVResponse, error)
+	List(ctx context.Context, domain, project string, limit, offset int64, options ...FindOption) (*model.KVResponse, error)
 	Delete(ctx context.Context, kvID string, domain, project string) error
 	//FindKV is usually for service to pull configs
-	FindKV(ctx context.Context, domain, project string, options ...FindOption) ([]*model.KVResponse, error)
+	FindKV(ctx context.Context, domain, project string, limit, offset int64, options ...FindOption) ([]*model.KVResponse, error)
 }
 
 //History provide api of History entity
 type History interface {
-	GetHistory(ctx context.Context, keyID string, options ...FindOption) ([]*model.KVDoc, error)
+	GetHistory(ctx context.Context, keyID string, limit, offset int64, options ...FindOption) ([]*model.KVDoc, error)
 }
 type Revision interface {
 	GetRevision(ctx context.Context) (int64, error)


### PR DESCRIPTION
1. GET 接口提供分页功能，以 queryParams 传入 limit 和 offset 参数；
2. offset 和 limit 可缺省，可只设置一个值，也可都设置，缺省状态不分页
3. 入参校验，offset >= 0，1 <= limit <=50
4. 增加了 mongodb 慢查询日志
5. 同步补齐了 ut 和 doc
6. 优化部分命名和格式