### PR TITLE
 fix the issue #99 that the key parameters in path does not effect

### DIFF
--- a/scripts/travis/start_deps.sh
+++ b/scripts/travis/start_deps.sh
@@ -17,4 +17,5 @@
 
 cd build
 bash build_docker.sh
+sudo docker-compose -f $GOPATH/src/github.com/apache/servicecomb-kie/deployments/docker/docker-compose.yaml down
 sudo docker-compose -f $GOPATH/src/github.com/apache/servicecomb-kie/deployments/docker/docker-compose.yaml up -d

--- a/scripts/travis/unit_test.sh
+++ b/scripts/travis/unit_test.sh
@@ -18,6 +18,7 @@ set -e
 # Make the Coverage File
 echo "mode: atomic" > coverage.txt
 
+go clean -testcache
 #Start the Test
 for d in $(go list ./... | grep -v vendor |  grep -v third_party | grep -v examples); do
     echo $d

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -363,7 +363,7 @@ func (r *KVResource) URLPatterns() []restful.Route {
 			ResourceFunc: r.GetByKey,
 			FuncDesc:     "get key values by key and labels",
 			Parameters: []*restful.Parameters{
-				DocPathProject, DocPathKey, DocQueryLabelParameters, DocQueryMatch, DocQueryRev,
+				DocPathProject, DocPathKey, DocQueryLabelParameters, DocQueryWait, DocQueryMatch, DocQueryRev,
 			},
 			Returns: []*restful.Returns{
 				{
@@ -399,7 +399,7 @@ func (r *KVResource) URLPatterns() []restful.Route {
 			ResourceFunc: r.List,
 			FuncDesc:     "list key values by labels and key",
 			Parameters: []*restful.Parameters{
-				DocPathProject, DocQueryLabelParameters, DocQueryWait, DocQueryMatch,
+				DocPathProject, DocQueryLabelParameters, DocQueryWait, DocQueryMatch, DocQueryRev,
 			},
 			Returns: []*restful.Returns{
 				{

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -118,7 +118,7 @@ func (r *KVResource) GetByKey(rctx *restful.Context) {
 		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	returnData(rctx, domain, project, labels, pageNum, pageSize, status, insID)
+	returnData(rctx, domain, project, key, labels, pageNum, pageSize, status, insID)
 }
 
 //List response kv list
@@ -149,10 +149,10 @@ func (r *KVResource) List(rctx *restful.Context) {
 		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	returnData(rctx, domain, project, labels, pageNum, pageSize, status, sessionID)
+	returnData(rctx, domain, project, "", labels, pageNum, pageSize, status, sessionID)
 }
 
-func returnData(rctx *restful.Context, domain interface{}, project string, labels map[string]string, pageNum, pageSize int64, status, sessionID string) {
+func returnData(rctx *restful.Context, domain interface{}, project, key string, labels map[string]string, pageNum, pageSize int64, status, sessionID string) {
 	revStr := rctx.ReadQueryParameter(common.QueryParamRev)
 	wait := rctx.ReadQueryParameter(common.QueryParamWait)
 	if sessionID != "" {
@@ -160,7 +160,7 @@ func returnData(rctx *restful.Context, domain interface{}, project string, label
 	}
 	if revStr == "" {
 		if wait == "" {
-			queryAndResponse(rctx, domain, project, "", labels, pageNum, pageSize, status)
+			queryAndResponse(rctx, domain, project, key, labels, pageNum, pageSize, status)
 			return
 		}
 		changed, err := eventHappened(rctx, wait, &pubsub.Topic{
@@ -174,7 +174,7 @@ func returnData(rctx *restful.Context, domain interface{}, project string, label
 			return
 		}
 		if changed {
-			queryAndResponse(rctx, domain, project, "", labels, pageNum, pageSize, status)
+			queryAndResponse(rctx, domain, project, key, labels, pageNum, pageSize, status)
 			return
 		}
 		rctx.WriteHeader(http.StatusNotModified)
@@ -189,7 +189,7 @@ func returnData(rctx *restful.Context, domain interface{}, project string, label
 			return
 		}
 		if revised {
-			queryAndResponse(rctx, domain, project, "", labels, pageNum, pageSize, status)
+			queryAndResponse(rctx, domain, project, key, labels, pageNum, pageSize, status)
 			return
 		} else if wait != "" {
 			changed, err := eventHappened(rctx, wait, &pubsub.Topic{
@@ -203,7 +203,7 @@ func returnData(rctx *restful.Context, domain interface{}, project string, label
 				return
 			}
 			if changed {
-				queryAndResponse(rctx, domain, project, "", labels, pageNum, pageSize, status)
+				queryAndResponse(rctx, domain, project, key, labels, pageNum, pageSize, status)
 				return
 			}
 			rctx.WriteHeader(http.StatusNotModified)


### PR DESCRIPTION
修改原因：
Fixes #99 
修改内容：
将key参数值通过returnData函数的参数传给queryAndResponse，并配入FindOption中