### PR TITLE
refactor polling detail

### DIFF
--- a/examples/dev/conf/chassis.yaml
+++ b/examples/dev/conf/chassis.yaml
@@ -10,7 +10,7 @@ cse:
   handler:
     chain:
       Provider:
-        default: auth-handler,ratelimiter-provider
+        default: auth-handler,track-handler,ratelimiter-provider
 # ssl:
 #   Provider.cipherPlugin: default
 #   Provider.verifyPeer: false

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -27,6 +27,7 @@ const (
 	QueryParamRev    = "revision"
 	QueryParamMatch  = "match"
 	QueryParamKeyID  = "kv_id"
+	QueryParamLabel  = "label"
 	QueryParamStatus = "status"
 	QueryParamOffset = "offset"
 	QueryParamLimit  = "limit"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -38,7 +38,7 @@ cse:
   handler:
     chain:
       Provider:
-        default: auth-handler,ratelimiter-provider
+        default: auth-handler,track-handler,ratelimiter-provider
 EOM
 cat <<EOM > ${root_dir}/conf/lager.yaml
 logger_level: ${LOG_LEVEL}

--- a/server/handler/track_handler.go
+++ b/server/handler/track_handler.go
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handler
+
+import (
+	"github.com/apache/servicecomb-kie/pkg/common"
+	"github.com/apache/servicecomb-kie/pkg/iputil"
+	"github.com/apache/servicecomb-kie/pkg/model"
+	"github.com/apache/servicecomb-kie/server/resource/v1"
+	"github.com/apache/servicecomb-kie/server/service/mongo/record"
+	"github.com/emicklei/go-restful"
+	"github.com/go-chassis/go-chassis/core/handler"
+	"github.com/go-chassis/go-chassis/core/invocation"
+	"github.com/go-mesh/openlogging"
+	"net/http"
+	"strings"
+)
+
+//const of noop auth handler
+const (
+	TrackHandlerName = "track-handler"
+)
+
+//TrackHandler tracks polling data
+type TrackHandler struct{}
+
+//Handle set local attribute to http request
+func (h *TrackHandler) Handle(chain *handler.Chain, inv *invocation.Invocation, cb invocation.ResponseCallBack) {
+	req, ok := inv.Args.(*restful.Request)
+	if !ok {
+		chain.Next(inv, cb)
+		return
+	}
+	if req.Request.Method != http.MethodGet {
+		chain.Next(inv, cb)
+		return
+	}
+	if !strings.Contains(req.Request.URL.Path, "kie/kv") {
+		chain.Next(inv, cb)
+		return
+	}
+	sessionID := req.HeaderParameter(v1.HeaderSessionID)
+	if sessionID == "" {
+		chain.Next(inv, cb)
+		return
+	}
+	chain.Next(inv, func(ir *invocation.Response) error {
+		resp, ok := ir.Result.(*restful.Response)
+		if !ok {
+			err := cb(ir)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+		revStr := req.QueryParameter(common.QueryParamRev)
+		wait := req.QueryParameter(common.QueryParamWait)
+		data := &model.PollingDetail{}
+		data.URLPath = req.Request.Method + " " + req.Request.URL.Path
+		data.SessionID = sessionID
+		data.UserAgent = req.HeaderParameter(v1.HeaderUserAgent)
+		data.Domain = inv.Metadata[v1.AttributeDomainKey].(string)
+		data.IP = iputil.ClientIP(req.Request)
+		data.ResponseBody = inv.Ctx.Value(common.RespBodyContextKey)
+		data.ResponseCode = ir.Status
+		data.ResponseHeader = resp.Header()
+		data.PollingData = map[string]interface{}{
+			"revStr":  revStr,
+			"wait":    wait,
+			"project": req.HeaderParameter(v1.PathParameterProject),
+			"labels":  req.QueryParameter("label"),
+		}
+		_, err := record.CreateOrUpdate(inv.Ctx, data)
+		if err != nil {
+			openlogging.Warn("record polling detail failed" + err.Error())
+			err := cb(ir)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+		err = cb(ir)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+}
+
+func newTrackHandler() handler.Handler {
+	return &TrackHandler{}
+}
+
+//Name is handler name
+func (h *TrackHandler) Name() string {
+	return TrackHandlerName
+}
+func init() {
+	if err := handler.RegisterHandler(TrackHandlerName, newTrackHandler); err != nil {
+		openlogging.Fatal("register handler failed: " + err.Error())
+	}
+}

--- a/server/service/mongo/record/polling_detail_dao.go
+++ b/server/service/mongo/record/polling_detail_dao.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"github.com/apache/servicecomb-kie/pkg/model"
 	"github.com/apache/servicecomb-kie/server/service/mongo/session"
+	uuid "github.com/satori/go.uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -32,6 +33,7 @@ func CreateOrUpdate(ctx context.Context, detail *model.PollingDetail) (*model.Po
 	res := collection.FindOne(ctx, queryFilter)
 	if res.Err() != nil {
 		if res.Err() == mongo.ErrNoDocuments {
+			detail.ID = uuid.NewV4().String()
 			_, err := collection.InsertOne(ctx, detail)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
- 代码坏味道，有3个方法有过多的入参
- 错误的uuid生成方式，不该每次都生成，只需要在创建时生成
- domain在同表中两个字段都记录了，冗余了
- 使用handler这种优雅方式记录推送轨迹，功能剥离具体业务代码
- 不对domain为空进行错误返回，统一在handler里处理才对，到业务中默认就一定是有的

#79 