### PR TITLE
kv history support rotate

### DIFF
--- a/deployments/db.js
+++ b/deployments/db.js
@@ -55,7 +55,7 @@ db.createCollection( "kv", {
             }
         } }
 } );
-
+db.createCollection("kv_revision");
 db.createCollection( "label", {
     validator: { $jsonSchema: {
             bsonType: "object",
@@ -135,6 +135,7 @@ db.createCollection( "polling_detail", {
 //index
 db.kv.createIndex({"id": 1}, { unique: true } );
 db.kv.createIndex({key: 1, label_id: 1,domain:1,project:1},{ unique: true });
+db.kv_revision.createIndex( { "delete_time": 1 }, { expireAfterSeconds: 7 * 24 * 3600 } );
 db.label.createIndex({"id": 1}, { unique: true } );
 db.label.createIndex({format: 1,domain:1,project:1},{ unique: true });
 db.polling_detail.createIndex({"id": 1}, { unique: true } );

--- a/pkg/model/db_schema.go
+++ b/pkg/model/db_schema.go
@@ -39,8 +39,8 @@ type KVDoc struct {
 	UpdateRevision int64  `json:"update_revision,omitempty" bson:"update_revision," yaml:"update_revision,omitempty"`
 	Project        string `json:"project,omitempty" yaml:"project,omitempty"`
 	Status         string `json:"status,omitempty" yaml:"status,omitempty"`
-	CreatTime      string `json:"create_time,omitempty" yaml:"create_time,omitempty"`
-	UpdateTime     string `json:"update_time,omitempty" yaml:"update_time,omitempty"`
+	CreateTime     string `json:"create_time,omitempty" bson:"create_time," yaml:"create_time,omitempty"`
+	UpdateTime     string `json:"update_time,omitempty" bson:"update_time," yaml:"update_time,omitempty"`
 
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"` //redundant
 	Domain string            `json:"domain,omitempty" yaml:"domain,omitempty"` //redundant

--- a/server/service/mongo/kv/kv_dao.go
+++ b/server/service/mongo/kv/kv_dao.go
@@ -48,7 +48,7 @@ func createKey(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, error) {
 	}
 	kv.UpdateRevision = revision
 	kv.CreateRevision = revision
-	kv.CreatTime = time.Now().String()
+	kv.CreateTime = time.Now().String()
 	kv.UpdateTime = time.Now().String()
 	_, err = collection.InsertOne(ctx, kv)
 	if err != nil {
@@ -182,6 +182,10 @@ func deleteKV(ctx context.Context, kvID, project, domain string) error {
 		openlogging.Warn(fmt.Sprintf("failed, may have been deleted,kvID=%s", kvID))
 	} else {
 		openlogging.Info(fmt.Sprintf("delete success,kvID=%s", kvID))
+	}
+	err = history.AddDeleteTime(ctx, kvID, project, domain)
+	if err != nil {
+		openlogging.Error(fmt.Sprintf("add delete time to [%s] failed : [%s]", kvID, err))
 	}
 	return err
 }

--- a/server/service/mongo/session/session.go
+++ b/server/service/mongo/session/session.go
@@ -206,7 +206,7 @@ func InitMongodb() {
 		panic(err)
 	}
 	//kv
-	c = session.DB("kie").C("kv")
+	c = session.DB(DBName).C("kv")
 	err = c.Create(&mgo.CollectionInfo{Validator: bson.M{
 		"key":     bson.M{"$exists": true},
 		"domain":  bson.M{"$exists": true},
@@ -227,7 +227,15 @@ func InitMongodb() {
 	if err != nil {
 		panic(err)
 	}
-
+	//kv_revision
+	c = session.DB(DBName).C(CollectionKVRevision)
+	err = c.EnsureIndex(mgo.Index{
+		Key:         []string{"delete_time"},
+		ExpireAfter: 7 * 24 * time.Hour,
+	})
+	if err != nil {
+		panic(err)
+	}
 	//label
 	c = session.DB(DBName).C(CollectionLabel)
 	err = c.Create(&mgo.CollectionInfo{Validator: bson.M{


### PR DESCRIPTION
1. kv history对每个key保存100条历史记录
2. 删除key时给key对应的所有历史记录打上删除时间戳，由mongodb的TTL index功能实现在7天后自动删除这些数据

Fixes #120