### PR TITLE
refactor apis

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -13,6 +13,9 @@ paths:
           in: path
           required: true
           type: string
+        - name: key
+          in: query
+          type: string
         - name: label
           in: query
           description: label pairs,for example &label=service:order&label=version:1.0.0
@@ -91,70 +94,18 @@ paths:
           description: ""
           schema:
             $ref: '#/definitions/DocResponseSingleKey'
-    delete:
-      summary: delete key by kv ID.
-      operationId: Delete
+  /v1/{project}/kie/kv/{kv_id}:
+    get:
+      summary: get key values by kv_id
+      operationId: Get
       parameters:
         - name: project
           in: path
           required: true
           type: string
         - name: kv_id
-          in: query
-          required: true
-          type: string
-      consumes:
-        - '*/*'
-      produces:
-        - '*/*'
-      responses:
-        "204":
-          description: Delete success
-        "500":
-          description: Server error
-  /v1/{project}/kie/kv/{key}:
-    get:
-      summary: get key values by key and labels
-      operationId: GetByKey
-      parameters:
-        - name: project
           in: path
           required: true
-          type: string
-        - name: key
-          in: path
-          required: true
-          type: string
-        - name: label
-          in: query
-          description: label pairs,for example &label=service:order&label=version:1.0.0
-          type: string
-        - name: wait
-          in: query
-          description: wait until any kv changed. for example wait=5s, server will not
-            response until 5 seconds, during that time window, if any kv changed, server
-            will return 200 and kv list, otherwise return 304 and empty body
-          type: string
-        - name: match
-          in: query
-          description: match works with label query param, it specifies label match
-            pattern. if it is empty, server will return kv which's labels partial match
-            the label query param. uf it is exact, server will return kv which's labels
-            exact match the label query param
-          type: string
-        - name: revision
-          in: query
-          description: each time you query,server will return a number in header X-Kie-Revision.
-            you can record it in client side, use this number as param value. if current
-            revision is greater than it, server will return data
-          type: string
-        - name: limit
-          in: query
-          description: pagination
-          type: string
-        - name: offset
-          in: query
-          description: pagination
           type: string
       consumes:
         - '*/*'
@@ -165,15 +116,14 @@ paths:
         "200":
           description: get key value success
           schema:
-            $ref: '#/definitions/DocResponseGetKey'
+            $ref: '#/definitions/DocResponseSingleKey'
           headers:
             X-Kie-Revision:
               description: cluster latest revision number, if key value is changed,
                 it will increase.
               type: integer
-        "304":
-          description: empty body
-  /v1/{project}/kie/kv/{kv_id}:
+        "404":
+          description: key value not found
     put:
       summary: update a key value
       operationId: Put
@@ -208,6 +158,29 @@ paths:
           description: ""
           schema:
             $ref: '#/definitions/DocResponseSingleKey'
+    delete:
+      summary: delete key by kv ID.
+      operationId: Delete
+      parameters:
+        - name: project
+          in: path
+          required: true
+          type: string
+        - name: kv_id
+          in: path
+          required: true
+          type: string
+      consumes:
+        - '*/*'
+      produces:
+        - '*/*'
+      responses:
+        "204":
+          description: delete success
+        "404":
+          description: no key value found for deletion
+        "500":
+          description: server error
   /v1/{project}/kie/revision/{kv_id}:
     get:
       summary: get all revisions by key id
@@ -231,9 +204,7 @@ paths:
         "200":
           description: ""
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/DocResponseSingleKey'
+            $ref: '#/definitions/DocResponseGetKey'
   /v1/{project}/kie/track:
     get:
       summary: get polling tracks of clients of kie server
@@ -357,9 +328,9 @@ definitions:
       params:
         type: object
         additionalProperties:
-          type: interface {}
+          type: string
       response_body:
-        type: interface {}
+        type: string
       response_code:
         type: integer
         format: int32

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -61,13 +61,36 @@ paths:
               type: integer
         "304":
           description: empty body
-        "404":
+    post:
+      summary: create a key value
+      operationId: Post
+      parameters:
+        - name: project
+          in: path
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: used to indicate the media type of the resource, the value can
+            be application/json or text/yaml
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1.KVCreateBody'
+      consumes:
+        - application/json
+        - text/yaml
+      produces:
+        - application/json
+        - text/yaml
+      responses:
+        "200":
           description: ""
-          headers:
-            X-Kie-Revision:
-              description: cluster latest revision number, if key value is changed,
-                it will increase.
-              type: integer
+          schema:
+            $ref: '#/definitions/DocResponseSingleKey'
     delete:
       summary: delete key by kv ID.
       operationId: Delete
@@ -150,35 +173,30 @@ paths:
               type: integer
         "304":
           description: empty body
-        "404":
-          description: ""
-          headers:
-            X-Kie-Revision:
-              description: cluster latest revision number, if key value is changed,
-                it will increase.
-              type: integer
+  /v1/{project}/kie/kv/{kv_id}:
     put:
-      summary: create or update key value
+      summary: update a key value
       operationId: Put
       parameters:
         - name: project
           in: path
           required: true
           type: string
-        - name: key
+        - name: kv_id
           in: path
           required: true
           type: string
         - name: Content-Type
           in: header
+          description: used to indicate the media type of the resource, the value can
+            be application/json or text/yaml
           required: true
-          description: used to indicate the media type of the resource, the value can be application/json or text/yaml
           type: string
         - name: body
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1.KVBody'
+            $ref: '#/definitions/v1.KVUpdateBody'
       consumes:
         - application/json
         - text/yaml
@@ -190,7 +208,7 @@ paths:
           description: ""
           schema:
             $ref: '#/definitions/DocResponseSingleKey'
-  /v1/{project}/kie/revision/{key_id}:
+  /v1/{project}/kie/revision/{kv_id}:
     get:
       summary: get all revisions by key id
       operationId: GetRevisions
@@ -199,7 +217,7 @@ paths:
           in: path
           required: true
           type: string
-        - name: key_id
+        - name: kv_id
           in: path
           required: true
           type: string
@@ -339,9 +357,9 @@ definitions:
       params:
         type: object
         additionalProperties:
-          type: string
+          type: interface {}
       response_body:
-        type: string
+        type: interface {}
       response_code:
         type: integer
         format: int32
@@ -355,14 +373,25 @@ definitions:
         type: string
       user_agent:
         type: string
-  v1.KVBody:
+  v1.KVCreateBody:
     type: object
     properties:
+      key:
+        type: string
       labels:
         type: object
         additionalProperties:
           type: string
+      status:
+        type: string
       value:
         type: string
       value_type:
+        type: string
+  v1.KVUpdateBody:
+    type: object
+    properties:
+      status:
+        type: string
+      value:
         type: string

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -21,16 +21,18 @@ import "time"
 
 //match mode
 const (
-	QueryParamQ      = "q"
-	QueryByLabelsCon = "&"
-	QueryParamWait   = "wait"
-	QueryParamRev    = "revision"
-	QueryParamMatch  = "match"
-	QueryParamKVID   = "kv_id"
-	QueryParamLabel  = "label"
-	QueryParamStatus = "status"
-	QueryParamOffset = "offset"
-	QueryParamLimit  = "limit"
+	QueryParamQ          = "q"
+	QueryByLabelsCon     = "&"
+	QueryParamWait       = "wait"
+	QueryParamRev        = "revision"
+	QueryParamMatch      = "match"
+	QueryParamKey        = "key"
+	QueryParamLabel      = "label"
+	QueryParamStatus     = "status"
+	QueryParamOffset     = "offset"
+	QueryParamLimit      = "limit"
+	PathParamKVID        = "kv_id"
+	PathParameterProject = "project"
 	//polling data
 	QueryParamSessionID = "sessionId"
 	QueryParamIP        = "ip"
@@ -59,14 +61,13 @@ const (
 	StatusEnabled           = "enabled"
 	StatusDisabled          = "disabled"
 	MsgDomainMustNotBeEmpty = "domain must not be empty"
-	MsgKeyMustNotBeEmpty    = "key must not be empty"
+	MsgDeleteKVFailed       = "delete kv failed"
 	MsgIllegalLabels        = "label value can not be empty, " +
 		"label can not be duplicated, please check query parameters"
-	MsgIllegalDepth     = "X-Depth must be number"
-	MsgInvalidWait      = "wait param should be formed with number and time unit like 5s,100ms, and less than 5m"
-	MsgInvalidRev       = "revision param should be formed with number greater than 0"
-	ErrKvIDMustNotEmpty = "must supply kv id if you want to remove key"
-	RespBodyContextKey  = "responseBody"
+	MsgIllegalDepth    = "X-Depth must be number"
+	MsgInvalidWait     = "wait param should be formed with number and time unit like 5s,100ms, and less than 5m"
+	MsgInvalidRev      = "revision param should be formed with number greater than 0"
+	RespBodyContextKey = "responseBody"
 
 	MaxWait = 5 * time.Minute
 )

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -26,7 +26,7 @@ const (
 	QueryParamWait   = "wait"
 	QueryParamRev    = "revision"
 	QueryParamMatch  = "match"
-	QueryParamKeyID  = "kv_id"
+	QueryParamKVID   = "kv_id"
 	QueryParamLabel  = "label"
 	QueryParamStatus = "status"
 	QueryParamOffset = "offset"
@@ -59,6 +59,7 @@ const (
 	StatusEnabled           = "enabled"
 	StatusDisabled          = "disabled"
 	MsgDomainMustNotBeEmpty = "domain must not be empty"
+	MsgKeyMustNotBeEmpty    = "key must not be empty"
 	MsgIllegalLabels        = "label value can not be empty, " +
 		"label can not be duplicated, please check query parameters"
 	MsgIllegalDepth     = "X-Depth must be number"

--- a/server/handler/track_handler.go
+++ b/server/handler/track_handler.go
@@ -77,7 +77,7 @@ func (h *TrackHandler) Handle(chain *handler.Chain, inv *invocation.Invocation, 
 		data.PollingData = map[string]interface{}{
 			"revStr":  revStr,
 			"wait":    wait,
-			"project": req.HeaderParameter(v1.PathParameterProject),
+			"project": req.HeaderParameter(common.PathParameterProject),
 			"labels":  req.QueryParameter("label"),
 		}
 		_, err := track.CreateOrUpdate(inv.Ctx, data)

--- a/server/resource/v1/doc_struct.go
+++ b/server/resource/v1/doc_struct.go
@@ -90,7 +90,7 @@ var (
 	}
 	DocQueryKeyIDParameters = &restful.Parameters{
 		DataType:  "string",
-		Name:      common.QueryParamKeyID,
+		Name:      common.QueryParamKVID,
 		ParamType: goRestful.QueryParameterKind,
 		Required:  true,
 	}
@@ -155,17 +155,25 @@ var (
 	}
 	DocPathKeyID = &restful.Parameters{
 		DataType:  "string",
-		Name:      "key_id",
+		Name:      "kv_id",
 		ParamType: goRestful.PathParameterKind,
 		Required:  true,
 	}
 )
 
-//KVBody is open api doc
-type KVBody struct {
+//KVCreateBody is open api doc
+type KVCreateBody struct {
+	Key       string            `json:"key"`
 	Labels    map[string]string `json:"labels"`
-	ValueType string            `json:"value_type"`
+	Status    string            `json:"status"`
 	Value     string            `json:"value"`
+	ValueType string            `json:"value_type"`
+}
+
+//KVUpdateBody is open api doc
+type KVUpdateBody struct {
+	Status    string `json:"status"`
+	Value     string `json:"value"`
 }
 
 //ErrorMsg is open api doc

--- a/server/resource/v1/doc_struct.go
+++ b/server/resource/v1/doc_struct.go
@@ -88,11 +88,10 @@ var (
 			"if it is empty, server will return kv which's labels partial match the label query param. " +
 			"uf it is exact, server will return kv which's labels exact match the label query param",
 	}
-	DocQueryKeyIDParameters = &restful.Parameters{
+	DocQueryKeyParameters = &restful.Parameters{
 		DataType:  "string",
-		Name:      common.QueryParamKVID,
+		Name:      common.QueryParamKey,
 		ParamType: goRestful.QueryParameterKind,
-		Required:  true,
 	}
 	DocQueryLabelParameters = &restful.Parameters{
 		DataType:  "string",
@@ -141,21 +140,15 @@ var (
 
 //swagger doc path params
 var (
-	DocPathKey = &restful.Parameters{
-		DataType:  "string",
-		Name:      "key",
-		ParamType: goRestful.PathParameterKind,
-		Required:  true,
-	}
 	DocPathProject = &restful.Parameters{
 		DataType:  "string",
-		Name:      "project",
+		Name:      common.PathParameterProject,
 		ParamType: goRestful.PathParameterKind,
 		Required:  true,
 	}
 	DocPathKeyID = &restful.Parameters{
 		DataType:  "string",
-		Name:      "kv_id",
+		Name:      common.PathParamKVID,
 		ParamType: goRestful.PathParameterKind,
 		Required:  true,
 	}
@@ -172,8 +165,8 @@ type KVCreateBody struct {
 
 //KVUpdateBody is open api doc
 type KVUpdateBody struct {
-	Status    string `json:"status"`
-	Value     string `json:"value"`
+	Status string `json:"status"`
+	Value  string `json:"value"`
 }
 
 //ErrorMsg is open api doc

--- a/server/resource/v1/history_resource.go
+++ b/server/resource/v1/history_resource.go
@@ -40,7 +40,7 @@ type HistoryResource struct {
 //GetRevisions search key only by label
 func (r *HistoryResource) GetRevisions(context *restful.Context) {
 	var err error
-	kvID := context.ReadPathParameter(common.QueryParamKVID)
+	kvID := context.ReadPathParameter(common.PathParamKVID)
 	offsetStr := context.ReadQueryParameter(common.QueryParamOffset)
 	limitStr := context.ReadQueryParameter(common.QueryParamLimit)
 	offset, limit, err := checkPagination(offsetStr, limitStr)
@@ -49,13 +49,11 @@ func (r *HistoryResource) GetRevisions(context *restful.Context) {
 		return
 	}
 	if kvID == "" {
-		openlogging.Error("key id is nil")
+		openlogging.Error("kv id is nil")
 		WriteErrResponse(context, http.StatusForbidden, "kv_id must not be empty", common.ContentTypeText)
 		return
 	}
-	key := context.ReadQueryParameter("key")
 	revisions, err := service.HistoryService.GetHistory(context.Ctx, kvID,
-		service.WithKey(key),
 		service.WithOffset(offset),
 		service.WithLimit(limit))
 	if err != nil {
@@ -147,7 +145,7 @@ func (r *HistoryResource) URLPatterns() []restful.Route {
 			Returns: []*restful.Returns{
 				{
 					Code:  http.StatusOK,
-					Model: []model.DocResponseSingleKey{},
+					Model: model.DocResponseGetKey{},
 				},
 			},
 			Consumes: []string{goRestful.MIME_JSON, common.ContentTypeYaml},

--- a/server/resource/v1/history_resource.go
+++ b/server/resource/v1/history_resource.go
@@ -40,7 +40,7 @@ type HistoryResource struct {
 //GetRevisions search key only by label
 func (r *HistoryResource) GetRevisions(context *restful.Context) {
 	var err error
-	keyID := context.ReadPathParameter("key_id")
+	kvID := context.ReadPathParameter(common.QueryParamKVID)
 	offsetStr := context.ReadQueryParameter(common.QueryParamOffset)
 	limitStr := context.ReadQueryParameter(common.QueryParamLimit)
 	offset, limit, err := checkPagination(offsetStr, limitStr)
@@ -48,13 +48,13 @@ func (r *HistoryResource) GetRevisions(context *restful.Context) {
 		WriteErrResponse(context, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	if keyID == "" {
+	if kvID == "" {
 		openlogging.Error("key id is nil")
-		WriteErrResponse(context, http.StatusForbidden, "key_id must not be empty", common.ContentTypeText)
+		WriteErrResponse(context, http.StatusForbidden, "kv_id must not be empty", common.ContentTypeText)
 		return
 	}
 	key := context.ReadQueryParameter("key")
-	revisions, err := service.HistoryService.GetHistory(context.Ctx, keyID,
+	revisions, err := service.HistoryService.GetHistory(context.Ctx, kvID,
 		service.WithKey(key),
 		service.WithOffset(offset),
 		service.WithLimit(limit))
@@ -138,7 +138,7 @@ func (r *HistoryResource) URLPatterns() []restful.Route {
 	return []restful.Route{
 		{
 			Method:       http.MethodGet,
-			Path:         "/v1/{project}/kie/revision/{key_id}",
+			Path:         "/v1/{project}/kie/revision/{kv_id}",
 			ResourceFunc: r.GetRevisions,
 			FuncDesc:     "get all revisions by key id",
 			Parameters: []*restful.Parameters{

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -19,6 +19,7 @@
 package v1
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -37,49 +38,45 @@ type KVResource struct {
 }
 
 //Post create a kv
-func (r *KVResource) Post(context *restful.Context) {
+func (r *KVResource) Post(rctx *restful.Context) {
 	var err error
-	project := context.ReadPathParameter(PathParameterProject)
-	kvDoc := new(model.KVDoc)
-	if err = readRequest(context, kvDoc); err != nil {
-		WriteErrResponse(context, http.StatusBadRequest, err.Error(), common.ContentTypeText)
+	project := rctx.ReadPathParameter(common.PathParameterProject)
+	kv := new(model.KVDoc)
+	if err = readRequest(rctx, kv); err != nil {
+		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	if kvDoc.Key == "" {
-		WriteErrResponse(context, http.StatusBadRequest, common.MsgKeyMustNotBeEmpty, common.ContentTypeText)
-		return
-	}
-	domain := ReadDomain(context)
-	kvDoc.Domain = domain.(string)
-	kvDoc.Project = project
-	_, err = checkStatus(kvDoc.Status)
+	domain := ReadDomain(rctx)
+	kv.Domain = domain.(string)
+	kv.Project = project
+	err = validatePost(kv)
 	if err != nil {
-		WriteErrResponse(context, http.StatusInternalServerError, err.Error(), common.ContentTypeText)
+		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	kv, err := service.KVService.Create(context.Ctx, kvDoc)
+	kv, err = service.KVService.Create(rctx.Ctx, kv)
 	if err != nil {
-		openlogging.Error(fmt.Sprintf("post [%v] err:%s", kvDoc, err.Error()))
+		openlogging.Error(fmt.Sprintf("post err:%s", err.Error()))
 		if err == session.ErrKVAlreadyExists {
-			WriteErrResponse(context, http.StatusConflict, err.Error(), common.ContentTypeText)
+			WriteErrResponse(rctx, http.StatusConflict, err.Error(), common.ContentTypeText)
 			return
 		}
-		WriteErrResponse(context, http.StatusInternalServerError, err.Error(), common.ContentTypeText)
+		WriteErrResponse(rctx, http.StatusInternalServerError, "create kv failed", common.ContentTypeText)
 		return
 	}
 	err = pubsub.Publish(&pubsub.KVChangeEvent{
-		Key:      kvDoc.Key,
-		Labels:   kvDoc.Labels,
+		Key:      kv.Key,
+		Labels:   kv.Labels,
 		Project:  project,
-		DomainID: kvDoc.Domain,
+		DomainID: kv.Domain,
 		Action:   pubsub.ActionPut,
 	})
 	if err != nil {
 		openlogging.Warn("lost kv change event when post:" + err.Error())
 	}
 	openlogging.Info(
-		fmt.Sprintf("post [%s] success", kvDoc.Key))
-	err = writeResponse(context, kv)
+		fmt.Sprintf("post [%s] success", kv.ID))
+	err = writeResponse(rctx, kv)
 	if err != nil {
 		openlogging.Error(err.Error())
 	}
@@ -87,28 +84,28 @@ func (r *KVResource) Post(context *restful.Context) {
 }
 
 //Put update a kv
-func (r *KVResource) Put(context *restful.Context) {
+func (r *KVResource) Put(rctx *restful.Context) {
 	var err error
-	kvID := context.ReadPathParameter(common.QueryParamKVID)
-	project := context.ReadPathParameter(PathParameterProject)
+	kvID := rctx.ReadPathParameter(common.PathParamKVID)
+	project := rctx.ReadPathParameter(common.PathParameterProject)
 	kv := new(model.KVDoc)
-	if err = readRequest(context, kv); err != nil {
-		WriteErrResponse(context, http.StatusBadRequest, err.Error(), common.ContentTypeText)
+	if err = readRequest(rctx, kv); err != nil {
+		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	domain := ReadDomain(context)
+	domain := ReadDomain(rctx)
 	kv.ID = kvID
 	kv.Domain = domain.(string)
 	kv.Project = project
-	_, err = checkStatus(kv.Status)
+	err = validatePut(kv)
 	if err != nil {
-		WriteErrResponse(context, http.StatusInternalServerError, err.Error(), common.ContentTypeText)
+		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	kv, err = service.KVService.Update(context.Ctx, kv)
+	kv, err = service.KVService.Update(rctx.Ctx, kv)
 	if err != nil {
-		openlogging.Error(fmt.Sprintf("put [%v] err:%s", kv, err.Error()))
-		WriteErrResponse(context, http.StatusInternalServerError, err.Error(), common.ContentTypeText)
+		openlogging.Error(fmt.Sprintf("put [%s] err:%s", kvID, err.Error()))
+		WriteErrResponse(rctx, http.StatusInternalServerError, "update kv failed", common.ContentTypeText)
 		return
 	}
 	err = pubsub.Publish(&pubsub.KVChangeEvent{
@@ -122,60 +119,57 @@ func (r *KVResource) Put(context *restful.Context) {
 		openlogging.Warn("lost kv change event when put:" + err.Error())
 	}
 	openlogging.Info(
-		fmt.Sprintf("put [%s] success", kv.Key))
-	err = writeResponse(context, kv)
+		fmt.Sprintf("put [%s] success", kvID))
+	err = writeResponse(rctx, kv)
 	if err != nil {
 		openlogging.Error(err.Error())
 	}
 
 }
 
-//GetByKey search key by label and key
-func (r *KVResource) GetByKey(rctx *restful.Context) {
-	var err error
-	key := rctx.ReadPathParameter(PathParameterKey)
-	if key == "" {
-		WriteErrResponse(rctx, http.StatusBadRequest, common.MsgKeyMustNotBeEmpty, common.ContentTypeText)
-		return
-	}
-	project := rctx.ReadPathParameter(PathParameterProject)
-	labels, err := getLabels(rctx)
-	if err != nil {
-		WriteErrResponse(rctx, http.StatusBadRequest, common.MsgIllegalLabels, common.ContentTypeText)
-		return
-	}
-	domain := ReadDomain(rctx)
-	offsetStr := rctx.ReadQueryParameter(common.QueryParamOffset)
-	limitStr := rctx.ReadQueryParameter(common.QueryParamLimit)
-	offset, limit, err := checkPagination(offsetStr, limitStr)
+//Get search key by kv id
+func (r *KVResource) Get(rctx *restful.Context) {
+	project := rctx.ReadPathParameter(common.PathParameterProject)
+	domain := ReadDomain(rctx).(string)
+	kvID := rctx.ReadPathParameter(common.PathParamKVID)
+	err := validateGet(domain, project, kvID)
 	if err != nil {
 		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	sessionID := rctx.ReadHeader(HeaderSessionID)
-	statusStr := rctx.ReadQueryParameter(common.QueryParamStatus)
-	status, err := checkStatus(statusStr)
+	kv, err := service.KVService.Get(rctx.Ctx, domain, project, kvID)
 	if err != nil {
-		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
+		openlogging.Error("kv_resource: " + err.Error())
+		if err == service.ErrKeyNotExists {
+			WriteErrResponse(rctx, http.StatusNotFound, err.Error(), common.ContentTypeText)
+			return
+		}
+		WriteErrResponse(rctx, http.StatusInternalServerError, "get kv failed", common.ContentTypeText)
 		return
 	}
-	returnData(rctx, &model.KVDoc{
-		Domain:  domain.(string),
-		Project: project,
-		Key:     key,
-		Labels:  labels,
-		Status:  status,
-	}, offset, limit, sessionID)
+	kv.Domain = ""
+	kv.Project = ""
+	err = writeResponse(rctx, kv)
+	rctx.Ctx = context.WithValue(rctx.Ctx, common.RespBodyContextKey, kv)
+	if err != nil {
+		openlogging.Error(err.Error())
+	}
 }
 
 //List response kv list
 func (r *KVResource) List(rctx *restful.Context) {
 	var err error
-	project := rctx.ReadPathParameter(PathParameterProject)
-	domain := ReadDomain(rctx)
-	labels, err := getLabels(rctx)
+	key := rctx.ReadQueryParameter(common.QueryParamKey)
+	project := rctx.ReadPathParameter(common.PathParameterProject)
+	domain := ReadDomain(rctx).(string)
+	err = validateList(domain, project)
 	if err != nil {
 		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
+		return
+	}
+	labels, err := getLabels(rctx)
+	if err != nil {
+		WriteErrResponse(rctx, http.StatusBadRequest, common.MsgIllegalLabels, common.ContentTypeText)
 		return
 	}
 
@@ -194,8 +188,9 @@ func (r *KVResource) List(rctx *restful.Context) {
 		return
 	}
 	returnData(rctx, &model.KVDoc{
-		Domain:  domain.(string),
+		Domain:  domain,
 		Project: project,
+		Key:     key,
 		Labels:  labels,
 		Status:  status,
 	}, offset, limit, sessionID)
@@ -261,42 +256,45 @@ func returnData(rctx *restful.Context, doc *model.KVDoc, offset, limit int64, se
 }
 
 //Delete deletes key by ids
-func (r *KVResource) Delete(context *restful.Context) {
-	project := context.ReadPathParameter(PathParameterProject)
-	domain := ReadDomain(context)
-	kvID := context.ReadQueryParameter(common.QueryParamKVID)
-	if kvID == "" {
-		WriteErrResponse(context, http.StatusBadRequest, common.ErrKvIDMustNotEmpty, common.ContentTypeText)
+func (r *KVResource) Delete(rctx *restful.Context) {
+	project := rctx.ReadPathParameter(common.PathParameterProject)
+	domain := ReadDomain(rctx).(string)
+	kvID := rctx.ReadPathParameter(common.PathParamKVID)
+	err := validateDelete(domain, project, kvID)
+	if err != nil {
+		WriteErrResponse(rctx, http.StatusBadRequest, err.Error(), common.ContentTypeText)
 		return
 	}
-	kv, err := service.KVService.Get(context.Ctx, domain.(string), project, kvID)
-	if err != nil && err != service.ErrKeyNotExists {
-		WriteErrResponse(context, http.StatusInternalServerError, err.Error(), common.ContentTypeText)
-		return
-	} else if err == service.ErrKeyNotExists {
-		context.WriteHeader(http.StatusNoContent)
+	kv, err := service.KVService.Get(rctx.Ctx, domain, project, kvID)
+	if err != nil {
+		openlogging.Error("kv_resource: " + err.Error())
+		if err == service.ErrKeyNotExists {
+			WriteErrResponse(rctx, http.StatusNotFound, err.Error(), common.ContentTypeText)
+			return
+		}
+		WriteErrResponse(rctx, http.StatusInternalServerError, common.MsgDeleteKVFailed, common.ContentTypeText)
 		return
 	}
-	err = service.KVService.Delete(context.Ctx, kvID, domain.(string), project)
+	err = service.KVService.Delete(rctx.Ctx, kvID, domain, project)
 	if err != nil {
 		openlogging.Error("delete failed ,", openlogging.WithTags(openlogging.Tags{
 			"kvID":  kvID,
 			"error": err.Error(),
 		}))
-		WriteErrResponse(context, http.StatusInternalServerError, err.Error(), common.ContentTypeText)
+		WriteErrResponse(rctx, http.StatusInternalServerError, common.MsgDeleteKVFailed, common.ContentTypeText)
 		return
 	}
 	err = pubsub.Publish(&pubsub.KVChangeEvent{
 		Key:      kv.Key,
 		Labels:   kv.Labels,
 		Project:  project,
-		DomainID: domain.(string),
+		DomainID: domain,
 		Action:   pubsub.ActionDelete,
 	})
 	if err != nil {
 		openlogging.Warn("lost kv change event:" + err.Error())
 	}
-	context.WriteHeader(http.StatusNoContent)
+	rctx.WriteHeader(http.StatusNoContent)
 }
 
 //URLPatterns defined config operations
@@ -338,25 +336,24 @@ func (r *KVResource) URLPatterns() []restful.Route {
 			Produces: []string{goRestful.MIME_JSON, common.ContentTypeYaml},
 		}, {
 			Method:       http.MethodGet,
-			Path:         "/v1/{project}/kie/kv/{key}",
-			ResourceFunc: r.GetByKey,
-			FuncDesc:     "get key values by key and labels",
+			Path:         "/v1/{project}/kie/kv/{kv_id}",
+			ResourceFunc: r.Get,
+			FuncDesc:     "get key values by kv_id",
 			Parameters: []*restful.Parameters{
-				DocPathProject, DocPathKey, DocQueryLabelParameters, DocQueryWait, DocQueryMatch, DocQueryRev,
-				DocQueryLimitParameters, DocQueryOffsetParameters,
+				DocPathProject, DocPathKeyID,
 			},
 			Returns: []*restful.Returns{
 				{
 					Code:    http.StatusOK,
 					Message: "get key value success",
-					Model:   model.DocResponseGetKey{},
+					Model:   model.DocResponseSingleKey{},
 					Headers: map[string]goRestful.Header{
 						common.HeaderRevision: DocHeaderRevision,
 					},
 				},
 				{
-					Code:    http.StatusNotModified,
-					Message: "empty body",
+					Code:    http.StatusNotFound,
+					Message: "key value not found",
 				},
 			},
 			Produces: []string{goRestful.MIME_JSON, common.ContentTypeYaml},
@@ -366,7 +363,7 @@ func (r *KVResource) URLPatterns() []restful.Route {
 			ResourceFunc: r.List,
 			FuncDesc:     "list key values by labels and key",
 			Parameters: []*restful.Parameters{
-				DocPathProject, DocQueryLabelParameters, DocQueryWait, DocQueryMatch, DocQueryRev,
+				DocPathProject, DocQueryKeyParameters, DocQueryLabelParameters, DocQueryWait, DocQueryMatch, DocQueryRev,
 				DocQueryLimitParameters, DocQueryOffsetParameters,
 			},
 			Returns: []*restful.Returns{
@@ -384,21 +381,25 @@ func (r *KVResource) URLPatterns() []restful.Route {
 			Produces: []string{goRestful.MIME_JSON, common.ContentTypeYaml},
 		}, {
 			Method:       http.MethodDelete,
-			Path:         "/v1/{project}/kie/kv",
+			Path:         "/v1/{project}/kie/kv/{kv_id}",
 			ResourceFunc: r.Delete,
 			FuncDesc:     "delete key by kv ID.",
 			Parameters: []*restful.Parameters{
 				DocPathProject,
-				DocQueryKeyIDParameters,
+				DocPathKeyID,
 			},
 			Returns: []*restful.Returns{
 				{
 					Code:    http.StatusNoContent,
-					Message: "Delete success",
+					Message: "delete success",
+				},
+				{
+					Code:    http.StatusNotFound,
+					Message: "no key value found for deletion",
 				},
 				{
 					Code:    http.StatusInternalServerError,
-					Message: "Server error",
+					Message: "server error",
 				},
 			},
 		},

--- a/server/service/mongo/kv/kv_service.go
+++ b/server/service/mongo/kv/kv_service.go
@@ -34,15 +34,82 @@ import (
 const (
 	MsgFindKvFailed    = "find kv failed, deadline exceeded"
 	MsgFindOneKey      = "find one key"
-	MsgFindOneKeyByID  = "find one key by id"
-	MsgFindMoreKey     = "find more"
-	MsgHitExactLabels  = "hit exact labels"
 	FmtErrFindKvFailed = "can not find kv in %s"
 )
 
 //Service operate data in mongodb
 type Service struct {
 	timeout time.Duration
+}
+
+//Create will create a key value record
+func (s *Service) Create(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, error) {
+	ctx, _ = context.WithTimeout(ctx, session.Timeout)
+	if kv.Domain == "" {
+		return nil, session.ErrMissingDomain
+	}
+	//check whether the project has certain labels or not
+	labelID, err := label.Exist(ctx, kv.Domain, kv.Project, kv.Labels)
+	if err != nil {
+		if err == session.ErrLabelNotExists {
+			l := &model.LabelDoc{
+				Domain:  kv.Domain,
+				Labels:  kv.Labels,
+				Project: kv.Project,
+			}
+			l, err = label.CreateLabel(ctx, l)
+			if err != nil {
+				openlogging.Error("create label failed", openlogging.WithTags(openlogging.Tags{
+					"k":      kv.Key,
+					"domain": kv.Domain,
+				}))
+				return nil, err
+			}
+			labelID = l.ID
+		} else {
+			return nil, err
+		}
+	}
+	kv.LabelID = labelID
+	if kv.ValueType == "" {
+		kv.ValueType = session.DefaultValueType
+	}
+	_, err = s.Exist(ctx, kv.Domain, kv.Key, kv.Project, service.WithLabelID(kv.LabelID))
+	if err == nil {
+		return nil, session.ErrKVAlreadyExists
+	}
+	if err != service.ErrKeyNotExists {
+		openlogging.Error(err.Error())
+		return nil, err
+	}
+	kv, err = createKey(ctx, kv)
+	if err != nil {
+		openlogging.Error(err.Error())
+		return nil, err
+	}
+	clearPart(kv)
+	return kv, nil
+}
+
+//Update will update a key value record
+func (s *Service) Update(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, error) {
+	ctx, _ = context.WithTimeout(ctx, session.Timeout)
+	if kv.Domain == "" {
+		return nil, session.ErrMissingDomain
+	}
+	oldKV, err := s.Get(ctx, kv.Domain, kv.Project, kv.ID)
+	if err != nil {
+		return nil, err
+	}
+	oldKV.Status = kv.Status
+	oldKV.Value = kv.Value
+	err = updateKeyValue(ctx, oldKV)
+	if err != nil {
+		return nil, err
+	}
+	clearPart(oldKV)
+	return oldKV, nil
+
 }
 
 //CreateOrUpdate will create or update a key value record
@@ -194,7 +261,7 @@ func (s *Service) List(ctx context.Context, domain, project string, options ...s
 }
 
 //Get get kvs by id
-func (s *Service) Get(ctx context.Context, domain, project, id string, options ...service.FindOption) (*model.KVResponse, error) {
+func (s *Service) Get(ctx context.Context, domain, project, id string, options ...service.FindOption) (*model.KVDoc, error) {
 	opts := service.FindOptions{}
 	for _, o := range options {
 		o(&opts)
@@ -211,5 +278,5 @@ func (s *Service) Get(ctx context.Context, domain, project, id string, options .
 	if id == "" {
 		return nil, session.ErrIDIsNil
 	}
-	return findKVByID(ctx, domain, project, id)
+	return findKVDocByID(ctx, domain, project, id)
 }

--- a/server/service/mongo/kv/tool.go
+++ b/server/service/mongo/kv/tool.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apache/servicecomb-kie/pkg/model"
 )
 
+//clearPart remove domain and project of kv
 func clearPart(kv *model.KVDoc) {
 	kv.Domain = ""
 	kv.Project = ""

--- a/server/service/mongo/kv/tool.go
+++ b/server/service/mongo/kv/tool.go
@@ -18,28 +18,10 @@
 package kv
 
 import (
-	"context"
 	"github.com/apache/servicecomb-kie/pkg/model"
 )
 
-//clearAll clean attr which don't need to return to client side
-func clearAll(kv *model.KVDoc) {
-	clearPart(kv)
-	kv.Labels = nil
-	kv.LabelID = ""
-}
 func clearPart(kv *model.KVDoc) {
 	kv.Domain = ""
 	kv.Project = ""
-}
-
-func findKVByID(ctx context.Context, domain, project, kvID string) (*model.KVResponse, error) {
-	kv, err := findKVDocByID(ctx, domain, project, kvID)
-	if err != nil {
-		return nil, err
-	}
-	return &model.KVResponse{
-		Total: 1,
-		Data:  []*model.KVDoc{kv},
-	}, nil
 }

--- a/server/service/mongo/session/session.go
+++ b/server/service/mongo/session/session.go
@@ -62,6 +62,7 @@ var (
 	ErrKeyMustNotEmpty = errors.New("must supply key if you want to get exact one result")
 
 	ErrIDIsNil                = errors.New("id is empty")
+	ErrKeyIsNil               = errors.New("key must not be empty")
 	ErrKvIDAndLabelIDNotMatch = errors.New("kvID and labelID do not match")
 	ErrRootCAMissing          = errors.New("rootCAFile is empty in config file")
 	ErrKVAlreadyExists        = errors.New("kv already exists")

--- a/server/service/mongo/session/session.go
+++ b/server/service/mongo/session/session.go
@@ -64,6 +64,7 @@ var (
 	ErrIDIsNil                = errors.New("id is empty")
 	ErrKvIDAndLabelIDNotMatch = errors.New("kvID and labelID do not match")
 	ErrRootCAMissing          = errors.New("rootCAFile is empty in config file")
+	ErrKVAlreadyExists        = errors.New("kv already exists")
 
 	ErrViewCreation = errors.New("can not create view")
 	ErrViewUpdate   = errors.New("can not update view")

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -43,11 +43,13 @@ var (
 //KV provide api of KV entity
 type KV interface {
 	//below 3 methods is usually for admin console
+	Create(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, error)
+	Update(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, error)
 	CreateOrUpdate(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, error)
 	List(ctx context.Context, domain, project string, options ...FindOption) (*model.KVResponse, error)
 	Delete(ctx context.Context, kvID string, domain, project string) error
 	//Get return kv by id
-	Get(ctx context.Context, domain, project, id string, options ...FindOption) (*model.KVResponse, error)
+	Get(ctx context.Context, domain, project, id string, options ...FindOption) (*model.KVDoc, error)
 }
 
 //History provide api of History entity


### PR DESCRIPTION
修改原因：
Fixes #130

修改内容：
重构kv相关API，包括：
- 新增POST接口 POST /kv 传body体，若已存在则返回409错误，不会更新
- put API 不再兼容，旧API /kv/{key}删除，改为新的/kv/{kv_id}。 body传可更改的就可以了，目前可更改的只有status和value。若kv_id不存在则返回404，不会新增
- 变更 DELETE由/kv?kv_id={kv_id} 改为 /kv/{kv_id}
- 新增 GET /kv/{kv_id}， 原/kv/{key}通过/kv?key={key}实现

修改后查询有两种方式：
一种： GET /kv/{kv_id}  通过kv_id查询唯一kv，查不到返回404，立即返回，不支持watch。
另一种： GET /kv?key={key}&label=xxxx...  查询符合条件的kv List，与原来API的/kv/{key}?label=xxxx...功能一致，只是参数key从path中移到了query中。查不到返回是200。支持watch。