### PR TITLE
improvement: status is disabled by default

### DIFF
--- a/deployments/db.js
+++ b/deployments/db.js
@@ -50,6 +50,7 @@ db.createCollection( "kv", {
                     bsonType: "long",
                 },
                 status: {
+                    enum: [ "enabled","disabled" ],
                     bsonType: "string",
                 },
             }

--- a/server/resource/v1/history_resource_test.go
+++ b/server/resource/v1/history_resource_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	common2 "github.com/apache/servicecomb-kie/pkg/common"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -39,15 +40,17 @@ import (
 
 func TestHistoryResource_GetRevisions(t *testing.T) {
 	kv := &model.KVDoc{
-		Key:   "test",
-		Value: "revisions",
+		Key:    "test",
+		Value:  "revisions",
+		Status: common2.StatusEnabled,
 		Labels: map[string]string{
 			"test": "revisions",
 		},
 		Domain:  "default",
 		Project: "history_test",
 	}
-	kv, _ = service.KVService.Create(context.Background(), kv)
+	kv, err := service.KVService.Create(context.Background(), kv)
+	assert.NoError(t, err)
 	path := fmt.Sprintf("/v1/history_test/kie/revision/%s", kv.ID)
 	r, _ := http.NewRequest("GET", path, nil)
 	revision := &v1.HistoryResource{}

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -52,6 +52,9 @@ func (r *KVResource) Post(rctx *restful.Context) {
 	domain := ReadDomain(rctx)
 	kv.Domain = domain.(string)
 	kv.Project = project
+	if kv.Status == "" {
+		kv.Status = common.StatusDisabled
+	}
 	err = validate.Validate(kv)
 	if err != nil {
 		WriteErrResponse(rctx, http.StatusBadRequest, err.Error())
@@ -60,7 +63,7 @@ func (r *KVResource) Post(rctx *restful.Context) {
 	err = quota.PreCreate("", kv.Domain, "", 1)
 	if err != nil {
 		if err == quota.ErrReached {
-			openlogging.Info("can not create kv, due to quota violation")
+			openlogging.Info(fmt.Sprintf("can not create kv %s@%s, due to quota violation", kv.Key, kv.Project))
 			WriteErrResponse(rctx, http.StatusUnprocessableEntity, err.Error())
 			return
 		}

--- a/server/service/mongo/kv/kv_service.go
+++ b/server/service/mongo/kv/kv_service.go
@@ -77,8 +77,12 @@ func (s *Service) Update(ctx context.Context, kv *model.KVDoc) (*model.KVDoc, er
 	if err != nil {
 		return nil, err
 	}
-	oldKV.Status = kv.Status
-	oldKV.Value = kv.Value
+	if kv.Status != "" {
+		oldKV.Status = kv.Status
+	}
+	if kv.Value != "" {
+		oldKV.Value = kv.Value
+	}
 	err = updateKeyValue(ctx, oldKV)
 	if err != nil {
 		return nil, err

--- a/server/service/mongo/kv/kv_service_test.go
+++ b/server/service/mongo/kv/kv_service_test.go
@@ -19,6 +19,7 @@ package kv_test
 
 import (
 	"context"
+	common2 "github.com/apache/servicecomb-kie/pkg/common"
 	"github.com/apache/servicecomb-kie/pkg/model"
 	"github.com/apache/servicecomb-kie/server/config"
 	"github.com/apache/servicecomb-kie/server/service"
@@ -50,8 +51,9 @@ func TestService_CreateOrUpdate(t *testing.T) {
 	kvsvc := &kv.Service{}
 	t.Run("put kv timeout,with labels app and service", func(t *testing.T) {
 		kv, err := kvsvc.Create(context.TODO(), &model.KVDoc{
-			Key:   "timeout",
-			Value: "2s",
+			Key:    "timeout",
+			Value:  "2s",
+			Status: common2.StatusEnabled,
 			Labels: map[string]string{
 				"app":     "mall",
 				"service": "cart",
@@ -64,8 +66,9 @@ func TestService_CreateOrUpdate(t *testing.T) {
 	})
 	t.Run("put kv timeout,with labels app, service and version", func(t *testing.T) {
 		kv, err := kvsvc.Create(context.TODO(), &model.KVDoc{
-			Key:   "timeout",
-			Value: "2s",
+			Key:    "timeout",
+			Value:  "2s",
+			Status: common2.StatusEnabled,
 			Labels: map[string]string{
 				"app":     "mall",
 				"service": "cart",
@@ -86,8 +89,9 @@ func TestService_CreateOrUpdate(t *testing.T) {
 	})
 	t.Run("put kv timeout,with labels app,and update value", func(t *testing.T) {
 		beforeKV, err := kvsvc.Create(context.Background(), &model.KVDoc{
-			Key:   "timeout",
-			Value: "1s",
+			Key:    "timeout",
+			Value:  "1s",
+			Status: common2.StatusEnabled,
 			Labels: map[string]string{
 				"app": "mall",
 			},
@@ -119,8 +123,9 @@ func TestService_Create(t *testing.T) {
 	kvsvc := &kv.Service{}
 	t.Run("create kv timeout,with labels app and service", func(t *testing.T) {
 		result, err := kvsvc.Create(context.TODO(), &model.KVDoc{
-			Key:   "timeout",
-			Value: "2s",
+			Key:    "timeout",
+			Value:  "2s",
+			Status: common2.StatusEnabled,
 			Labels: map[string]string{
 				"app":     "mall",
 				"service": "utCart",
@@ -135,8 +140,9 @@ func TestService_Create(t *testing.T) {
 	})
 	t.Run("create the same kv", func(t *testing.T) {
 		_, err := kvsvc.Create(context.TODO(), &model.KVDoc{
-			Key:   "timeout",
-			Value: "2s",
+			Key:    "timeout",
+			Value:  "2s",
+			Status: common2.StatusEnabled,
 			Labels: map[string]string{
 				"app":     "mall",
 				"service": "utCart",

--- a/server/service/mongo/view/view_service_test.go
+++ b/server/service/mongo/view/view_service_test.go
@@ -20,6 +20,7 @@ package view_test
 import (
 	"context"
 	"encoding/json"
+	common2 "github.com/apache/servicecomb-kie/pkg/common"
 	"github.com/apache/servicecomb-kie/pkg/model"
 	"github.com/apache/servicecomb-kie/server/config"
 	"github.com/apache/servicecomb-kie/server/service"
@@ -40,8 +41,9 @@ func TestGet(t *testing.T) {
 	kvsvc := &kv.Service{}
 	t.Run("put view data", func(t *testing.T) {
 		kv, err := kvsvc.Create(context.TODO(), &model.KVDoc{
-			Key:   "timeout",
-			Value: "2s",
+			Key:    "timeout",
+			Value:  "2s",
+			Status: common2.StatusEnabled,
 			Labels: map[string]string{
 				"app":     "mall",
 				"service": "cart",
@@ -54,8 +56,9 @@ func TestGet(t *testing.T) {
 		assert.NotEmpty(t, kv.ID)
 
 		kv, err = kvsvc.Create(context.TODO(), &model.KVDoc{
-			Key:   "timeout",
-			Value: "2s",
+			Key:    "timeout",
+			Value:  "2s",
+			Status: common2.StatusEnabled,
 			Labels: map[string]string{
 				"app": "mall",
 			},
@@ -66,8 +69,9 @@ func TestGet(t *testing.T) {
 		assert.NotEmpty(t, kv.ID)
 
 		kv, err = kvsvc.Create(context.TODO(), &model.KVDoc{
-			Key:   "retry",
-			Value: "2",
+			Key:    "retry",
+			Value:  "2",
+			Status: common2.StatusEnabled,
 			Labels: map[string]string{
 				"app": "mall",
 			},


### PR DESCRIPTION
创建一个不生效的配置可以保证后续在UI再次的review，其实配置的生效是要很谨慎的，他通常涉及生产环境的系统行为。如果创建新配置时不明确指定status为enable，不该立即生效

修复bug：更新时应当对字段是否为空判断