### PR TITLE
validate rule change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apache/servicecomb-kie
 require (
 	github.com/emicklei/go-restful v2.12.0+incompatible
 	github.com/go-chassis/go-archaius v1.2.2-0.20200409030209-a48668e4a025
-	github.com/go-chassis/go-chassis v1.8.2-0.20200331092516-8cf0b374128b
+	github.com/go-chassis/go-chassis v1.8.2-0.20200426111522-0f37ad3d79e5
 	github.com/go-chassis/paas-lager v1.1.1
 	github.com/go-mesh/openlogging v1.0.1
 	github.com/go-playground/universal-translator v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/go-chassis/go-chassis v1.8.2-0.20200310060113-4b383ba3d3f0 h1:YD9MtuY
 github.com/go-chassis/go-chassis v1.8.2-0.20200310060113-4b383ba3d3f0/go.mod h1:sFnVxSvprpy6umPFK4uSdfCDdfqdgbp3FdW/CG0VNnE=
 github.com/go-chassis/go-chassis v1.8.2-0.20200331092516-8cf0b374128b h1:AvZjvPQdla1KoLrxbU8bohR3Y9FYnScZFY5KnK2HnSU=
 github.com/go-chassis/go-chassis v1.8.2-0.20200331092516-8cf0b374128b/go.mod h1:ooQ3peVePtKic3ci/vIGEmGHTC5/BxUeYLN+eKu+EUU=
+github.com/go-chassis/go-chassis v1.8.2-0.20200426111522-0f37ad3d79e5 h1:QpSTAsKX2S/H0lc7bPOrFGDlPLQGr86y+q4nt0r0lCg=
+github.com/go-chassis/go-chassis v1.8.2-0.20200426111522-0f37ad3d79e5/go.mod h1:ooQ3peVePtKic3ci/vIGEmGHTC5/BxUeYLN+eKu+EUU=
 github.com/go-chassis/go-chassis v1.8.2 h1:lX+XJbIGSkC4c+1h8IcoBQFEX9vaZ0+KNugE24Q/I/Y=
 github.com/go-chassis/go-restful-swagger20 v1.0.3-0.20200310030431-17d80f34264f h1:5QmmNpVcGqIc6tuKNe5EAI4PA8Yn2EL9Oee7YdcJ4PE=
 github.com/go-chassis/go-restful-swagger20 v1.0.3-0.20200310030431-17d80f34264f/go.mod h1:eW62fYuzlNFDvIacB6AV8bhUDCTy4myfTCv0bT9Gbb0=

--- a/pkg/validate/instance.go
+++ b/pkg/validate/instance.go
@@ -11,12 +11,12 @@ const (
 // custom validate rules
 // please use different tag names from third party tags
 var customRules = []*RegexValidateRule{
-	NewRule(key, commonNameRegexString, &Option{Min: 1, Max: 2048}), //2K
+	NewRule(key, commonNameRegexString, &Option{Min: 1, Max: 1024}), //2K
 	NewRule("commonName", commonNameRegexString, &Option{Min: 1, Max: 256}),
 	NewRule("valueType", `^(ini|json|text|yaml|properties){0,1}$`, nil),
 	NewRule("kvStatus", `^(enabled|disabled){0,1}$`, nil),
 	NewRule("value", asciiRegexString, &Option{Max: 2097152}), //ASCII, 2M
-	NewRule("lableKV", commonNameRegexString, &Option{Min: 1, Max: 32}),
+	NewRule("lableKV", commonNameRegexString, &Option{Max: 32}),
 	NewRule("check", asciiRegexString, &Option{Max: 1048576}), //ASCII, 1M
 }
 


### PR DESCRIPTION
1. mongodb index must be less than 1024 char.
2. label may contain empty environment string , label can be empty. 