### PR TITLE
supplement and modify the long pooling case

### DIFF
--- a/docs/configurations/long_polling.md
+++ b/docs/configurations/long_polling.md
@@ -1,9 +1,4 @@
-# Long polling
-*experimental*
-
-Kie leverage gossip protocol to broad cast cluster events. if client use query parameter "?wait=5s" to poll key value,
-this polling will become long polling and if there is key value change events, 
-server will response key values to client.
+# distribute
 
 kie must join to a cluster and listen to peer events
 
@@ -22,7 +17,7 @@ start another node
 condition: key value put or delete
 
 payload:
-```go
+```json
 {
   "Key": "timeout",
   "Action": "put",
@@ -34,3 +29,83 @@ payload:
   "Project": "default"
 }
 ```
+
+# Long polling
+*experimental*
+
+Kie leverage gossip protocol to broad cast cluster events. if client use query parameter "?wait=5s" to poll key value,
+this polling will become long polling and if there is key value change events, 
+server will response key values to client.
+
+## For example 
+
+Put a key 
+```shell script
+curl -X POST \
+  http://127.0.0.1:30110/v1/default/kie/kv/ \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "key": "timeout",
+    "value": "2s",
+    "labels": {
+        "service": "order"
+    }
+}'
+```
+
+Then, we get the id from response.
+```json
+{
+    "id": "ec4d8057-fc3e-4a78-b273-28e311187196",
+    "key": "timeout",
+    "value": "2s",
+    "value_type": "text",
+    "create_revision": 2,
+    "update_revision": 2,
+    "status": "disabled",
+    "create_time": 1596620728,
+    "update_time": 1596620728,
+    "labels": {
+        "service": "order"
+    }
+}
+```
+
+Open the another terminal test the long polling
+```shell script
+ curl -X GET http://127.0.0.1:30110/v1/default/kie/kv?wait=20s
+```
+After 20 seconds, return empty body and the status code is 304
+
+Then modify the value
+```shell script
+ curl -X PUT http://127.0.0.1:30110/v1/default/kie/kv/ec4d8057-fc3e-4a78-b273-28e311187196  \
+ -H 'Content-Type: application/json'   \
+ -d '{
+     "value": "8s"
+  }'
+```
+
+Terminal immediately shows the result
+```json
+{
+ "total": 1,
+ "data": [
+  {
+   "id": "ec4d8057-fc3e-4a78-b273-28e311187196",
+   "key": "timeout",
+   "value": "8s",
+   "value_type": "text",
+   "create_revision": 2,
+   "update_revision": 3,
+   "status": "disabled",
+   "create_time": 1596620728,
+   "update_time": 1596713915,
+   "labels": {
+    "service": "order"
+   }
+  }
+ ]
+}
+```
+


### PR DESCRIPTION
原来的long pooling文档中将长轮询和多节点部署放在了configuration 目录下，多节点部署和长轮询关系不是很密切，因此补充了长轮询的用例并放在了开发者指南目录下。