### PR TITLE
Abandoned : SCB-2096 The configuration center supports fuzzy query 

### DIFF
--- a/pkg/validate/instance.go
+++ b/pkg/validate/instance.go
@@ -5,6 +5,7 @@ var defaultValidator = NewValidator()
 const (
 	key                   = "key"
 	commonNameRegexString = `^[a-zA-Z0-9]*$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]*[a-zA-Z0-9]$`
+	getKeyRegexString     = `^[a-zA-Z0-9]*$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]*[a-zA-Z0-9]$|^beginWith\([a-zA-Z0-9][a-zA-Z0-9_\-.]*\)$`
 	asciiRegexString      = `^[\x00-\x7F]*$`
 )
 
@@ -12,7 +13,7 @@ const (
 // please use different tag names from third party tags
 var customRules = []*RegexValidateRule{
 	NewRule(key, commonNameRegexString, &Option{Min: 1, Max: 128}),
-	NewRule("getKey", commonNameRegexString, &Option{Max: 128}),
+	NewRule("getKey", getKeyRegexString, &Option{Max: 128}),
 	NewRule("commonName", commonNameRegexString, &Option{Min: 1, Max: 256}),
 	NewRule("valueType", `^$|^(ini|json|text|yaml|properties)$`, nil),
 	NewRule("kvStatus", `^$|^(enabled|disabled)$`, nil),

--- a/pkg/validate/instance_test.go
+++ b/pkg/validate/instance_test.go
@@ -107,4 +107,20 @@ func TestValidate(t *testing.T) {
 		Labels: map[string]string{string32 + "a": "a"},
 	}
 	assert.Error(t, validate.Validate(kvDoc))
+
+	ListKVRe := &model.ListKVRequest{Project: "a", Domain: "a",
+		Key:   "beginWith(a)",
+	}
+	assert.NoError(t, validate.Validate(ListKVRe))
+
+	ListKVRe = &model.ListKVRequest{Project: "a", Domain: "a",
+		Key:   "beginW(a)",
+	}
+	assert.Error(t, validate.Validate(ListKVRe))
+
+	ListKVRe = &model.ListKVRequest{Project: "a", Domain: "a",
+		Key:   "beginW()",
+	}
+	assert.Error(t, validate.Validate(ListKVRe))
+
 }

--- a/server/resource/v1/kv_resource_test.go
+++ b/server/resource/v1/kv_resource_test.go
@@ -315,6 +315,21 @@ func TestKVResource_List(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(result.Data))
 	})
+	t.Run("get one key, fuzzy match,should return 2 kv", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "/v1/kv_test/kie/kv?key=beginWith(time)", nil)
+		r.Header.Set("Content-Type", "application/json")
+		kvr := &v1.KVResource{}
+		c, err := restfultest.New(kvr, nil)
+		assert.NoError(t, err)
+		resp := httptest.NewRecorder()
+		c.ServeHTTP(resp, r)
+		body, err := ioutil.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		result := &model.KVResponse{}
+		err = json.Unmarshal(body, result)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(result.Data))
+	})
 	t.Run("get one key by service label should return 2 kv,delete one", func(t *testing.T) {
 		r, _ := http.NewRequest("GET", "/v1/kv_test/kie/kv?key=timeout&label=service:utService", nil)
 		r.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
In this method, I used functions in the **mongo** package to implement fuzzy matching. If the amount of data is large and the query frequency is high, in order to speed up the calculation, you can consider taking out the data at a time to build a dictionary tree for fuzzy matching. These can be constructed by different scenarios.