### PR TITLE
修复Linux 本地版Kie在部分机器上报找不到private ip的错误

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -49,11 +49,18 @@ func ParseConfig(args []string) (err error) {
 			Usage:       "kie use this ip port to join a kie cluster, example: --peer-addr=10.1.1.10:5000",
 			Destination: &config.Configurations.PeerAddr,
 			EnvVar:      "PEER_ADDR",
-		}, cli.StringFlag{
+		},
+		cli.StringFlag{
 			Name:        "listen-peer-addr",
 			Usage:       "listen on ip port, kie receive events example: --listen-peer-addr=10.1.1.10:5000",
 			Destination: &config.Configurations.ListenPeerAddr,
 			EnvVar:      "LISTEN_PEER_ADDR",
+		},
+		cli.StringFlag{
+			Name:        "advertise-addr",
+			Usage:       "kie advertise addr, kie advertise addr example: --advertise-addr=10.1.1.10:5000",
+			Destination: &config.Configurations.AdvertiseAddr,
+			EnvVar:      "ADVERTISE_ADDR",
 		},
 	}
 	app.Action = func(c *cli.Context) error {

--- a/server/pubsub/bus.go
+++ b/server/pubsub/bus.go
@@ -88,6 +88,7 @@ func Init() {
 	})
 }
 
+// set serf advertiseAddr value
 func setSerfAdvertiseAddr(conf *serf.Config, advertiseAddr string) {
 	conf.MemberlistConfig.AdvertiseAddr = advertiseAddr
 }

--- a/server/pubsub/bus.go
+++ b/server/pubsub/bus.go
@@ -18,6 +18,7 @@
 package pubsub
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -55,13 +56,16 @@ type Bus struct {
 func Init() {
 	once.Do(func() {
 		ac := agent.DefaultConfig()
+		sc := serf.DefaultConfig()
+		setSerfAdvertiseAddr(sc, ac.BindAddr)
 		if config.Configurations.ListenPeerAddr != "" {
 			ac.BindAddr = config.Configurations.ListenPeerAddr
 		}
 		if config.Configurations.AdvertiseAddr != "" {
 			ac.AdvertiseAddr = config.Configurations.AdvertiseAddr
+			serfAdvertiseAddr := strings.Split(config.Configurations.AdvertiseAddr, ":")
+			setSerfAdvertiseAddr(sc, serfAdvertiseAddr[0])
 		}
-		sc := serf.DefaultConfig()
 		if config.Configurations.NodeName != "" {
 			sc.NodeName = config.Configurations.NodeName
 		}
@@ -82,6 +86,10 @@ func Init() {
 			}
 		}
 	})
+}
+
+func setSerfAdvertiseAddr(conf *serf.Config, advertiseAddr string) {
+	conf.MemberlistConfig.AdvertiseAddr = advertiseAddr
 }
 
 //Start start serf agent


### PR DESCRIPTION
#218 修复Linux 本地版Kie在部分机器上报create memberlist: Failed to get final advertise address: No private IP address found, and explicit IP not provided