### PR TITLE
when etcd connection fails, if wait is not empty, set the timeout to wait

### DIFF
--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -205,6 +205,7 @@ func returnData(rctx *restful.Context, request *model.ListKVRequest) {
 	if wait != "" {
 		duration, err := time.ParseDuration(wait)
 		if err != nil {
+			WriteErrResponse(rctx, config.ErrInvalidParams, err.Error())
 			return
 		}
 


### PR DESCRIPTION
问题：
etcd挂了，sdk调用kie查询配置接口，query有等待时间wait和revision，sdk查询设置20秒超时，而kie会先查询revision，查询revision的时候无法连接etcd并且设置30秒超时，这会导致sdk一直无法获取kie的返回结果，日志显示连接超时并一直重试，期望是返回错误码即可。