### PR TITLE
Bug fix: remove unused import

### DIFF
--- a/cmd/kieserver/main.go
+++ b/cmd/kieserver/main.go
@@ -26,7 +26,6 @@ import (
 
 	//custom handlers
 	_ "github.com/apache/servicecomb-kie/server/handler"
-	_ "github.com/go-chassis/go-chassis/v2/middleware/jwt"
 	_ "github.com/go-chassis/go-chassis/v2/middleware/monitoring"
 	_ "github.com/go-chassis/go-chassis/v2/middleware/ratelimiter"
 


### PR DESCRIPTION
import jwt没有意义，原因是：使用jwt解析handler，必须先直接调用jwt的Use接口。