### PR TITLE
if no data is obtained from the cache and kv is null, a panic occurs when kv.data is used

### DIFF
--- a/server/resource/v1/common.go
+++ b/server/resource/v1/common.go
@@ -269,6 +269,12 @@ func queryFromCache(rctx *restful.Context, topic string) {
 		WriteErrResponse(rctx, queryErr.Code, queryErr.Message)
 		return
 	}
+	if kv == nil {
+		kv = &model.KVResponse{
+			Total: 0,
+			Data:  []*model.KVDoc{},
+		}
+	}
 	rctx.ReadResponseWriter().Header().Set(common.HeaderRevision, strconv.FormatInt(rev, 10))
 	err := writeResponse(rctx, kv)
 	rctx.ReadRestfulRequest().SetAttribute(common.RespBodyContextKey, kv.Data)

--- a/server/resource/v1/common.go
+++ b/server/resource/v1/common.go
@@ -263,7 +263,7 @@ func checkDomainAndProject(domain, project string) error {
 	}
 	return nil
 }
-func queryFromCache(rctx *restful.Context, topic string) {
+func QueryFromCache(rctx *restful.Context, topic string) {
 	rev, kv, queryErr := cache.CachedKV().Read(topic)
 	if queryErr != nil {
 		WriteErrResponse(rctx, queryErr.Code, queryErr.Message)
@@ -271,8 +271,7 @@ func queryFromCache(rctx *restful.Context, topic string) {
 	}
 	if kv == nil {
 		kv = &model.KVResponse{
-			Total: 0,
-			Data:  []*model.KVDoc{},
+			Data: []*model.KVDoc{},
 		}
 	}
 	rctx.ReadResponseWriter().Header().Set(common.HeaderRevision, strconv.FormatInt(rev, 10))

--- a/server/resource/v1/kv_resource.go
+++ b/server/resource/v1/kv_resource.go
@@ -272,7 +272,7 @@ func watch(rctx *restful.Context, request *model.ListKVRequest, wait string) boo
 		return true
 	}
 	if changed {
-		queryFromCache(rctx, topic)
+		QueryFromCache(rctx, topic)
 		return true
 	}
 	return false


### PR DESCRIPTION
当从缓存没有读到数据，对于得到的kv应该定义一个空的结构体而非null