### PR TITLE
[feat] use cari package's NewTask and NewTombstone functions and change db name in mongo model

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,11 @@ jobs:
     env:
       GO111MODULE: on
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+        id: go
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Fmt

--- a/.github/workflows/mongo_storage.yml
+++ b/.github/workflows/mongo_storage.yml
@@ -16,7 +16,7 @@ jobs:
         sudo docker-compose -f ./examples/dev/docker-compose.yaml up -d
         sleep 20
         export TEST_DB_KIND=mongo
-        export TEST_DB_URI=mongodb://kie:123@127.0.0.1:27017/kie
+        export TEST_DB_URI=mongodb://kie:123@127.0.0.1:27017/servicecomb
         time go test -v $(go list ./... | grep -v etcd |  grep -v third_party | grep -v examples)
     - name: Build kie images
       run: |

--- a/build/build_binary.sh
+++ b/build/build_binary.sh
@@ -68,7 +68,7 @@ EOM
 
 cat <<EOM > ${release_dir}/conf/kie-conf.yaml
 db:
-  uri: mongodb://root:root@127.0.0.1:27017/kie
+  uri: mongodb://root:root@127.0.0.1:27017/servicecomb
   type: mongodb
   poolSize: 10
   ssl: false

--- a/deployments/docker/docker-compose.yaml
+++ b/deployments/docker/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     ports:
       - 27017:27017
     environment:
-      MONGO_INITDB_DATABASE: kie
+      MONGO_INITDB_DATABASE: servicecomb
       MONGO_INITDB_ROOT_USERNAME: kie
       MONGO_INITDB_ROOT_PASSWORD: 123
     volumes:

--- a/docs/configurations/rbac.md
+++ b/docs/configurations/rbac.md
@@ -11,7 +11,7 @@ follow steps to enable service center [RBAC](https://service-center.readthedocs.
 2.edit kie-conf.yaml
 ```ini
 db:
-  uri: mongodb://kie:123@127.0.0.1:27017/kie
+  uri: mongodb://kie:123@127.0.0.1:27017/servicecomb
   type: mongodb
 rbac:
   enabled: true

--- a/docs/configurations/storage.md
+++ b/docs/configurations/storage.md
@@ -23,7 +23,7 @@ you can use mongo db as kie server storage to save configuration
 ### Example
 ```yaml
 db:
-  uri: mongodb://kie:123@127.0.0.1:27017/kie
+  uri: mongodb://kie:123@127.0.0.1:27017/servicecomb
   poolSize: 10
   timeout:  5s
   sslEnabled: true

--- a/docs/getstarted/install.md
+++ b/docs/getstarted/install.md
@@ -7,9 +7,9 @@ use the [db init script](https://github.com/apache/servicecomb-kie/blob/master/d
 
 ```shell script
 sudo docker run --name mongo -d \
-    -e "MONGO_INITDB_DATABASE=kie" \
-    -e "MONGO_INITDB_ROOT_USERNAME=root" \
-    -e "MONGO_INITDB_ROOT_PASSWORD=root" \
+    -e "MONGO_INITDB_DATABASE=servicecomb" \
+    -e "MONGO_INITDB_ROOT_USERNAME=kie" \
+    -e "MONGO_INITDB_ROOT_PASSWORD=123" \
     -p 27017:27017 \
     -v ./deployments/db.js:/docker-entrypoint-initdb.d/db.js:ro \
     mongo:4.0
@@ -21,8 +21,8 @@ Run kie server
 ```shell script
 sudo docker run --name kie-server -d \
     -e "MONGODB_ADDR=${MONGO_IP}:27017" \
-    -e "MONGODB_USER=root" \
-    -e "MONGODB_PWD=root" \
+    -e "MONGODB_USER=kie" \
+    -e "MONGODB_PWD=123" \
     -p 30110:30110 \
     servicecomb/kie
 ```

--- a/examples/dev/db.js
+++ b/examples/dev/db.js
@@ -22,7 +22,7 @@ db.createUser(
         roles: [
             {
                 role: "readWrite",
-                db: "kie"
+                db: "servicecomb"
             }
         ]
     }

--- a/examples/dev/docker-compose.yaml
+++ b/examples/dev/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     ports:
       - 27017:27017
     environment:
-      MONGO_INITDB_DATABASE: kie
+      MONGO_INITDB_DATABASE: servicecomb
       MONGO_INITDB_ROOT_USERNAME: kie
       MONGO_INITDB_ROOT_PASSWORD: 123
     volumes:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/apache/servicecomb-kie
 
 require (
 	github.com/emicklei/go-restful v2.12.0+incompatible
-	github.com/go-chassis/cari v0.5.1-0.20211127060616-302dc831a28f
+	github.com/go-chassis/cari v0.5.1-0.20211222030004-0bb606bff5c5
 	github.com/go-chassis/foundation v0.3.1-0.20210811025651-7f4d2b2b906c
 	github.com/go-chassis/go-archaius v1.5.2-0.20210301074935-e4694f6b077b
 	github.com/go-chassis/go-chassis/v2 v2.3.1-0.20211122011324-0a97efcf095b
@@ -18,4 +18,124 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-go 1.16
+require (
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e // indirect
+	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/aws/aws-sdk-go v1.34.28 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deckarep/golang-set v1.7.1 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-chassis/go-restful-swagger20 v1.0.3 // indirect
+	github.com/go-chassis/kie-client v0.1.0 // indirect
+	github.com/go-chassis/sc-client v0.6.1-0.20210918130508-2b9daad232da // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-playground/validator v9.31.0+incompatible // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt v3.2.1+incompatible // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/btree v1.0.1 // indirect
+	github.com/gorilla/websocket v1.4.3-0.20210424162022-e8629af678b7 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/go-msgpack v0.5.3 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.0 // indirect
+	github.com/hashicorp/go-syslog v1.0.0 // indirect
+	github.com/hashicorp/go-version v1.0.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/mdns v1.0.1 // indirect
+	github.com/hashicorp/memberlist v0.2.2 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jonboulle/clockwork v0.2.2 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/karlseguin/ccache/v2 v2.0.8 // indirect
+	github.com/klauspost/compress v1.9.5 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/miekg/dns v1.1.26 // indirect
+	github.com/mitchellh/cli v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/posener/complete v1.2.3 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.7.0 // indirect
+	github.com/soheilhy/cmux v0.1.5 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
+	github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc // indirect
+	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
+	go.etcd.io/bbolt v1.3.6 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0 // indirect
+	go.etcd.io/etcd/client/v2 v2.305.0 // indirect
+	go.etcd.io/etcd/client/v3 v3.5.0 // indirect
+	go.etcd.io/etcd/pkg/v3 v3.5.0 // indirect
+	go.etcd.io/etcd/raft/v3 v3.5.0 // indirect
+	go.etcd.io/etcd/server/v3 v3.5.0 // indirect
+	go.opentelemetry.io/contrib v0.20.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0 // indirect
+	go.opentelemetry.io/otel v0.20.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp v0.20.0 // indirect
+	go.opentelemetry.io/otel/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk/export/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/trace v0.20.0 // indirect
+	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apimachinery v0.17.0 // indirect
+	k8s.io/client-go v0.17.0 // indirect
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
+)
+
+go 1.17

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/go-chassis/cari v0.0.0-20201210041921-7b6fbef2df11/go.mod h1:MgtsEI0A
 github.com/go-chassis/cari v0.4.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/cari v0.5.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
-github.com/go-chassis/cari v0.5.1-0.20211127060616-302dc831a28f h1:H+P5YSpPaTV2wfnlYj8shLRLpSVYC9BrkVrJr+4Bcuo=
-github.com/go-chassis/cari v0.5.1-0.20211127060616-302dc831a28f/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
+github.com/go-chassis/cari v0.5.1-0.20211222030004-0bb606bff5c5 h1:rlz19OM0C6oD5pUvhqpK2yzU6pyH9M+bt/mglfZrt90=
+github.com/go-chassis/cari v0.5.1-0.20211222030004-0bb606bff5c5/go.mod h1:HG0Olv4sy/4e/3e9S0pofO0pzchaDjJ0hMweyFU7d5Q=
 github.com/go-chassis/foundation v0.2.2-0.20201210043510-9f6d3de40234/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.2.2/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.3.0/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=

--- a/server/datasource/dao.go
+++ b/server/datasource/dao.go
@@ -24,9 +24,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-chassis/cari/sync"
 	"github.com/go-chassis/openlog"
-	"github.com/gofrs/uuid"
 
 	"github.com/apache/servicecomb-kie/pkg/model"
 	"github.com/apache/servicecomb-kie/server/config"
@@ -163,28 +161,7 @@ func ClearPart(kv *model.KVDoc) {
 	kv.LabelFormat = ""
 }
 
-// NewTask return task with action and datatype
-func NewTask(domain, project, action, dataType string) (*sync.Task, error) {
-	taskId, err := uuid.NewV4()
-	if err != nil {
-		return nil, err
-	}
-	return &sync.Task{
-		TaskID:    taskId.String(),
-		Action:    action,
-		DataType:  dataType,
-		Domain:    domain,
-		Project:   project,
-		Timestamp: time.Now().Unix(),
-	}, nil
-}
-
-// NewTombstone return tombstone with resourceType ,domain and project
-func NewTombstone(domain, project, resourceType string) *sync.Tombstone {
-	return &sync.Tombstone{
-		ResourceType: resourceType,
-		Domain:       domain,
-		Project:      project,
-		Timestamp:    time.Now().Unix(),
-	}
+// TombstoneID return tombstone's resourceID, using key and labelFormat as resourceID
+func TombstoneID(kv *model.KVDoc) string {
+	return kv.Key + "/" + kv.LabelFormat
 }

--- a/server/datasource/mongo/session/session.go
+++ b/server/datasource/mongo/session/session.go
@@ -42,7 +42,7 @@ import (
 
 //const for db name and collection name
 const (
-	DBName = "kie"
+	DBName = "servicecomb"
 
 	CollectionLabel         = "label"
 	CollectionKV            = "kv"

--- a/server/datasource/mongo/session/session_test.go
+++ b/server/datasource/mongo/session/session_test.go
@@ -15,7 +15,7 @@ import (
 func TestGetColInfo(t *testing.T) {
 	var err error
 	err = session.Init(&datasource.Config{
-		URI:     "mongodb://kie:123@127.0.0.1:27017/kie",
+		URI:     "mongodb://kie:123@127.0.0.1:27017/servicecomb",
 		Timeout: 10 * time.Second,
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
issus: #233 
【修改内容】:
1、使用 cari 公共包的 NewTask 和 NewTombstone方法，替换原先的 kie 里面的 func
2、将db为mongo时的dbname由kie修改成servicecomb
【修改原因】:
1、抽取公共部分到第三方库用于使用
2、将mongo的dbname改成servicecomb是因为service-center这边也有task任务，若使用两个 db 这边不太好控制
【影响范围】：无
【自测情况】：不影响测试用例