### PR TITLE
change regular expression of getkey

### DIFF
--- a/pkg/validator/rule.go
+++ b/pkg/validator/rule.go
@@ -21,11 +21,11 @@ import "github.com/go-chassis/foundation/validator"
 
 const (
 	key                   = "key"
-	keyRegex              = `^[a-zA-Z0-9._:-]+$`
+	keyRegex              = `^[a-zA-Z0-9._:-]*$`
 	commonNameRegexString = `^[a-zA-Z0-9]*$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]*[a-zA-Z0-9]$`
 	labelKeyRegexString   = `^[a-zA-Z0-9]{1,32}$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]{1,30}[a-zA-Z0-9]$`
 	labelValueRegexString = `^[a-zA-Z0-9]{0,160}$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]{0,158}[a-zA-Z0-9]$`
-	getKeyRegexString     = `^[a-zA-Z0-9]*$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]*[a-zA-Z0-9]$|^beginWith\([a-zA-Z0-9][a-zA-Z0-9_\-.]*\)$|^wildcard\([a-zA-Z0-9*][a-zA-Z0-9_\-.*]*\)$`
+	getKeyRegexString     = `^[a-zA-Z0-9._:-]*$|^beginWith\([a-zA-Z0-9._:-]*\)$|^wildcard\([a-zA-Z0-9*._:-]*\)$`
 	asciiRegexString      = `^[\x00-\x7F]*$`
 	allCharString         = `.*`
 )

--- a/pkg/validator/rule.go
+++ b/pkg/validator/rule.go
@@ -21,7 +21,7 @@ import "github.com/go-chassis/foundation/validator"
 
 const (
 	key                   = "key"
-	keyRegex              = `^[a-zA-Z0-9._:-]*$`
+	keyRegex              = `^[a-zA-Z0-9._:-]+$`
 	commonNameRegexString = `^[a-zA-Z0-9]*$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]*[a-zA-Z0-9]$`
 	labelKeyRegexString   = `^[a-zA-Z0-9]{1,32}$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]{1,30}[a-zA-Z0-9]$`
 	labelValueRegexString = `^[a-zA-Z0-9]{0,160}$|^[a-zA-Z0-9][a-zA-Z0-9_\-.]{0,158}[a-zA-Z0-9]$`

--- a/pkg/validator/rule_test.go
+++ b/pkg/validator/rule_test.go
@@ -243,7 +243,7 @@ func TestGetKey(t *testing.T) {
 	listKvreq := model.ListKVRequest{
 		Project: "default",
 		Domain:  "default",
-		Key:     ``,
+		Key:     "beginWith(zZ12.-_:)",
 		Labels: map[string]string{
 			"service": "utService",
 		},

--- a/pkg/validator/rule_test.go
+++ b/pkg/validator/rule_test.go
@@ -238,3 +238,61 @@ func TestStatus(t *testing.T) {
 	}
 	assert.Error(t, validator.Validate(kvDoc))
 }
+
+func TestGetKey(t *testing.T) {
+	listKvreq := model.ListKVRequest{
+		Project: "default",
+		Domain:  "default",
+		Key:     ``,
+		Labels: map[string]string{
+			"service": "utService",
+		},
+		Offset: 0,
+		Limit:  10,
+		Status: "enabled",
+		Match:  "exact",
+	}
+	assert.NoError(t, validator.Validate(listKvreq))
+
+	listKvreq = model.ListKVRequest{
+		Project: "default",
+		Domain:  "default",
+		Key:     "wildcard(*IME*)",
+		Labels: map[string]string{
+			"service": "utService",
+		},
+		Offset: 0,
+		Limit:  10,
+		Status: "enabled",
+		Match:  "exact",
+	}
+	assert.NoError(t, validator.Validate(listKvreq))
+
+	listKvreq = model.ListKVRequest{
+		Project: "default",
+		Domain:  "default",
+		Key:     "zZ12.-_:",
+		Labels: map[string]string{
+			"service": "utService",
+		},
+		Offset: 0,
+		Limit:  10,
+		Status: "enabled",
+		Match:  "exact",
+	}
+	assert.NoError(t, validator.Validate(listKvreq))
+
+	listKvreq = model.ListKVRequest{
+		Project: "default",
+		Domain:  "default",
+		Key:     "wildcard(*zZ12.-_:*)",
+		Labels: map[string]string{
+			"service": "utService",
+		},
+		Offset: 0,
+		Limit:  10,
+		Status: "enabled",
+		Match:  "exact",
+	}
+	assert.NoError(t, validator.Validate(listKvreq))
+}


### PR DESCRIPTION
查询配置接口中会用到getkey的校验规则，为了适配key的校验规则，本次变更将放宽getkey的校验要求，兼容历史版本