### PR TITLE
[feat]get sync value from context instead of directly from configuration file

### DIFF
--- a/server/datasource/kv_dao_test.go
+++ b/server/datasource/kv_dao_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/servicecomb-kie/pkg/model"
 	"github.com/apache/servicecomb-kie/server/datasource"
 	kvsvc "github.com/apache/servicecomb-kie/server/service/kv"
+	"github.com/apache/servicecomb-kie/server/service/sync"
 	"github.com/apache/servicecomb-kie/test"
 	emodel "github.com/apache/servicecomb-service-center/eventbase/model"
 	"github.com/apache/servicecomb-service-center/eventbase/service/task"
@@ -115,7 +116,7 @@ func TestWithSync(t *testing.T) {
 	t.Run("create kv with sync enabled", func(t *testing.T) {
 		t.Run("creating a kv will create a task should pass", func(t *testing.T) {
 			// set the sync enabled
-			ctx := context.WithValue(context.Background(), "sync", true)
+			ctx := sync.NewContext(context.Background(), true)
 			kv1, err := kvsvc.Create(ctx, &model.KVDoc{
 				Key:    "sync-create",
 				Value:  "2s",
@@ -159,7 +160,7 @@ func TestWithSync(t *testing.T) {
 	t.Run("update kv with sync enabled", func(t *testing.T) {
 		t.Run("creating two kvs and updating them will create four tasks should pass", func(t *testing.T) {
 			// set the sync enabled
-			ctx := context.WithValue(context.Background(), "sync", true)
+			ctx := sync.NewContext(context.Background(), true)
 			kv1, err := kvsvc.Create(ctx, &model.KVDoc{
 				Key:    "sync-update-one",
 				Value:  "2s",

--- a/server/service/kv/kv_svc.go
+++ b/server/service/kv/kv_svc.go
@@ -33,7 +33,6 @@ import (
 	"github.com/apache/servicecomb-kie/pkg/concurrency"
 	"github.com/apache/servicecomb-kie/pkg/model"
 	"github.com/apache/servicecomb-kie/pkg/stringutil"
-	cfg "github.com/apache/servicecomb-kie/server/config"
 	"github.com/apache/servicecomb-kie/server/datasource"
 	"github.com/apache/servicecomb-kie/server/pubsub"
 )
@@ -275,7 +274,7 @@ func FindManyAndDelete(ctx context.Context, kvIDs []string, project, domain stri
 	var kvs []*model.KVDoc
 	var deleted int64
 	var err error
-	kvs, deleted, err = datasource.GetBroker().GetKVDao().FindManyAndDelete(ctx, kvIDs, project, domain, datasource.WithSync(cfg.GetSync().Enabled))
+	kvs, deleted, err = datasource.GetBroker().GetKVDao().FindManyAndDelete(ctx, kvIDs, project, domain, datasource.WithSync(isSyncEnabled(ctx)))
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/kv/kv_svc.go
+++ b/server/service/kv/kv_svc.go
@@ -39,7 +39,7 @@ import (
 
 var listSema = concurrency.NewSemaphore(concurrency.DefaultConcurrency)
 
-const Sync = "sync"
+const CtxSyncEnabled = "sync"
 
 func ListKV(ctx context.Context, request *model.ListKVRequest) (int64, *model.KVResponse, *errsvc.Error) {
 	opts := []datasource.FindOption{
@@ -305,7 +305,7 @@ func List(ctx context.Context, project, domain string, options ...datasource.Fin
 }
 
 func isSyncEnabled(ctx context.Context) bool {
-	val := ctx.Value(Sync)
+	val := ctx.Value(CtxSyncEnabled)
 	enabled, ok := val.(bool)
 	if !ok {
 		enabled = false

--- a/server/service/sync/sync.go
+++ b/server/service/sync/sync.go
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sync
+
+import (
+	"context"
+)
+
+type ctxKey string
+
+const CtxSyncEnabled ctxKey = "sync"
+
+func NewContext(ctx context.Context, enabled bool) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, CtxSyncEnabled, enabled)
+}
+
+func FromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	val := ctx.Value(CtxSyncEnabled)
+	enabled, ok := val.(bool)
+	if !ok {
+		enabled = false
+	}
+	return enabled
+}

--- a/server/service/sync/sync_test.go
+++ b/server/service/sync/sync_test.go
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sync_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/servicecomb-kie/server/service/sync"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewContext(t *testing.T) {
+	t.Run("parent is nil should new one", func(t *testing.T) {
+		ctx := sync.NewContext(nil, true)
+		assert.NotNil(t, ctx)
+		assert.True(t, sync.FromContext(ctx))
+	})
+	t.Run("parent is not nil should be ok", func(t *testing.T) {
+		ctx := sync.NewContext(context.Background(), true)
+		assert.NotNil(t, ctx)
+		assert.True(t, sync.FromContext(ctx))
+
+		ctx = sync.NewContext(context.Background(), false)
+		assert.False(t, sync.FromContext(ctx))
+	})
+}
+
+func TestFromContext(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"no ctx should return false", args{nil}, false},
+		{"ctx without sync should return false", args{context.Background()}, false},
+		{"ctx with sync=true should return true", args{sync.NewContext(context.Background(), true)}, true},
+		{"ctx with sync=false should return true", args{sync.NewContext(context.Background(), false)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sync.FromContext(tt.args.ctx); got != tt.want {
+				t.Errorf("FromContext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- 当前通过配置控制是否产生同步任务，会导致service层的依赖方只要调用此方法都会产生同步任务
- 实际需求是，只有resource层下发的操作才需要产生同步任务，故改为通过context传值判断