### PR TITLE
[fix]after rbac is enabled, filter kvs may return null

### DIFF
--- a/server/datasource/auth/filter_kvdoc.go
+++ b/server/datasource/auth/filter_kvdoc.go
@@ -20,7 +20,7 @@ package auth
 import "github.com/apache/servicecomb-kie/pkg/model"
 
 func FilterKVs(kvs []*model.KVDoc, labelsList []map[string]string) []*model.KVDoc {
-	var permKVs []*model.KVDoc
+	var permKVs = make([]*model.KVDoc, 0, len(kvs))
 	for _, kv := range kvs {
 		for _, labels := range labelsList {
 			if !matchOne(kv, labels) {

--- a/server/datasource/auth/filter_kvdoc_test.go
+++ b/server/datasource/auth/filter_kvdoc_test.go
@@ -53,3 +53,13 @@ func TestFilterKVs(t *testing.T) {
 	r := FilterKVs(kvs, permResourceLabel)
 	assert.Equal(t, 1, len(r))
 }
+
+func TestFilterKVsWithEmptyKvs(t *testing.T) {
+	permResourceLabel := []map[string]string{
+		{"environment": "production", "appId": "default", "service": "s1"},
+		{"environment": "testing"},
+	}
+	var kvs = make([]*model.KVDoc, 0, 3)
+	r := FilterKVs(kvs, permResourceLabel)
+	assert.NotNil(t, r)
+}


### PR DESCRIPTION
开启rbac，配置项为空时
无自定义配置组的角色查询结果为空数组
有自定义配置组的角色查询结果为null